### PR TITLE
Fixed: isConnected crash

### DIFF
--- a/www/ble.js
+++ b/www/ble.js
@@ -117,7 +117,7 @@ module.exports = {
     },
 
     isConnected: function (device_id, success, failure) {
-        cordova.exec(success, failure, 'BLE', 'isConnected', []);
+        cordova.exec(success, failure, 'BLE', 'isConnected', [device_id]);
     },
 
     isEnabled: function (success, failure) {


### PR DESCRIPTION
device_id should be used findPeripheralByUUID

https://github.com/don/cordova-plugin-ble-central/blob/master/src/ios/BLECentralPlugin.m#L255