### PR TITLE
Disconnect cancels pending connections on iOS

### DIFF
--- a/src/ios/BLECentralPlugin.m
+++ b/src/ios/BLECentralPlugin.m
@@ -81,7 +81,7 @@
 
     [connectCallbacks removeObjectForKey:uuid];
 
-    if (peripheral && peripheral.state == CBPeripheralStateConnected) {
+    if (peripheral && peripheral.state != CBPeripheralStateDisconnected) {
         [manager cancelPeripheralConnection:peripheral];
     }
 


### PR DESCRIPTION
There is no way to cancel pending connections in iOS. This change cancels active and pending connections to a peripheral.