### PR TITLE
Some devices don't advertise their own characteristics correctly, so …

### DIFF
--- a/src/android/Peripheral.java
+++ b/src/android/Peripheral.java
@@ -280,10 +280,9 @@ public class Peripheral extends BluetoothGattCallback {
         BluetoothGattService service = gatt.getService(serviceUUID);
         //BluetoothGattCharacteristic characteristic = service.getCharacteristic(characteristicUUID);
         BluetoothGattCharacteristic characteristic = findNotifyCharacteristic(service, characteristicUUID);
-        String key = generateHashKey(serviceUUID, characteristic);
-
+  
         if (characteristic != null) {
-
+            String key = generateHashKey(serviceUUID, characteristic);
             notificationCallbacks.put(key, callbackContext);
 
             if (gatt.setCharacteristicNotification(characteristic, true)) {
@@ -433,6 +432,12 @@ public class Peripheral extends BluetoothGattCallback {
                 break;
             }
         }
+        
+        // Some devices don't advertise their own characteristics correctly
+        if( characteristic == null ){
+          characteristic = service.getCharacteristic(characteristicUUID);
+        }
+        
         return characteristic;
     }
 


### PR DESCRIPTION
…if a write characteristic isn't found, try to get the characteristic from the service.

I have a device with a write characteristic that is used to set its clock. But the device describes the characteristic as being read only.  Since the plugin searches only the write characteristics I can't use it to set the clock. My suggestion is to get the characteristic from the service if a write characteristic can't be found. 

I guess it means that someone trying to write to a read characteristic wouldn't get a warning here, but they will get a failure eventually, when they try to write to it.


---
Also small fix, when a characteristic is null, check it before calling generateHashKey(), which uses the characteristic .