### PR TITLE
change errorType in ios 'didWriteValueForCharacteristic:error:'

### DIFF
--- a/src/ios/BLECentralPlugin.m
+++ b/src/ios/BLECentralPlugin.m
@@ -484,7 +484,7 @@
             NSLog(@"%@", error);
             pluginResult = [CDVPluginResult
                 resultWithStatus:CDVCommandStatus_ERROR
-                messageAsString:[error localizedDescription]
+                messageAsInt:[error code]
             ];
         } else {
             pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];


### PR DESCRIPTION
In the android part, the "write" call returns "status" as int, if an error occurs. In iOS, there is a "localizedDescription" and so on js layer it's not possible to catch an equal code. So in the first step it would be logical, to send from both platforms the code, so the custom JS can handle the error in it's favour. In the second step, it could be better to return a JSON object with a structure like 
error:
{
    code: int,
    localizedDescription: string
    [...]
}
