### PR TITLE
Minor correction index.js for the CC2650 example.

### DIFF
--- a/examples/sensortag_cc2650/www/js/index.js
+++ b/examples/sensortag_cc2650/www/js/index.js
@@ -172,9 +172,9 @@ var app = {
                   "Y: " + app.sensorMpu9250AccConvert(a[4]) + "<br/>" +
                   "Z: " + app.sensorMpu9250AccConvert(a[5]) + "<br/>" +
                   "Mag <br/>"+
-                  "X: " + a[3] + "<br/>" +
-                  "Y: " + a[4] + "<br/>" +
-                  "Z: " + a[5] + "<br/>" ;
+                  "X: " + a[6] + "<br/>" +
+                  "Y: " + a[7] + "<br/>" +
+                  "Z: " + a[8] + "<br/>" ;
 
         accelerometerData.innerHTML = message;
     },


### PR DESCRIPTION
Currently the "onAccelerometerData" function considers that the Mag data is on the 3,4,5 indexes.

I propose a small correction to the "onAccelerometerData" function in order to display the magnetometer values correctly by changing the indexes from 3,4,5 to 6,7,8.

 