### PR TITLE
Connect to no ble flag peripheral (Android SDK 23)

### DIFF
--- a/src/android/Peripheral.java
+++ b/src/android/Peripheral.java
@@ -64,7 +64,11 @@ public class Peripheral extends BluetoothGattCallback {
     public void connect(CallbackContext callbackContext, Activity activity) {
         BluetoothDevice device = getDevice();
         connectCallback = callbackContext;
-        gatt = device.connectGatt(activity, false, this);
+        if (Build.VERSION.SDK_INT < 23) {
+            gatt = device.connectGatt(activity, false, this);
+        } else {
+            gatt = device.connectGatt(activity, false, this, BluetoothDevice.TRANSPORT_LE);
+        }
 
         PluginResult result = new PluginResult(PluginResult.Status.NO_RESULT);
         result.setKeepCallback(true);


### PR DESCRIPTION
if type flag of advertising data of peripheral is not ble flag(0x06), android(SDK<23) will use classic port to connect peripheral, so conection will be fail

add connection port type for android(SDK 23)can connect to no ble type flag peripheral