### PR TITLE
Avoid iOS exception: separate mutation, enumeration of advertisement dict

### DIFF
--- a/src/ios/CBPeripheral+Extensions.m
+++ b/src/ios/CBPeripheral+Extensions.m
@@ -108,7 +108,7 @@ static char ADVERTISEMENT_RSSI_IDENTIFER;
     if (serviceData) {
         NSLog(@"%@", serviceData);
 
-        for(CBUUID *key in serviceData) {
+        for (CBUUID *key in [serviceData allKeys]) {
             [serviceData setObject:dataToArrayBuffer([serviceData objectForKey:key]) forKey:[key UUIDString]];
             [serviceData removeObjectForKey:key];
         }


### PR DESCRIPTION
Working on a Cordova application that needs to read individual bytes from a
BLE advertisement, I found that on iOS I would occasionally get an uncaught
NSException in the first for loop in serializableAdvertisementData().

I didn't know any Objective-C, but my colleague Asa Freedman could tell
what the for loop was doing, and that it would succeed when serviceData
had no more than one key, otherwise throwing NSException.

Here's a one-liner fix to enumerate a copy of the keys instead of the
object directly.

Signed-off-by: Lebbeous Fogle-Weekley <lebbeous@gmail.com>