### PR TITLE
include note in scan/startScan about LocationServices

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ Function `scan` scans for BLE devices.  The success callback is called each time
 
 Advertising information format varies depending on your platform. See [Advertising Data](#advertising-data) for more information.
 
+*Note* in Android SDK >= 23, Location Services must be enabled. If it has not been enabled, the scan method will return no results even when BLE devices are in proximity.
+
 ### Parameters
 
 - __services__: List of services to discover, or [] to find all devices
@@ -119,6 +121,8 @@ Function `startScan` scans for BLE devices.  The success callback is called each
     }
 
 Advertising information format varies depending on your platform. See [Advertising Data](#advertising-data) for more information.
+
+*Note* cf. note above about Location Services in Android SDK >= 23.
 
 ### Parameters
 


### PR DESCRIPTION
Many thanks for your fantastic plugin !
I just spent two hours pulling my hair out about why a new Nexus 7 2013 was not finding any BLE devices... will surely save someone else the trouble if this quirk is documented alongside scan/startScan
