### PR TITLE
Add the ability to update the connection listener.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "cordova-plugin-ble-central",
+  "name": "cordova-plugin-ble-central”,
   "version": "1.1.3",
   "description": "Bluetooth Low Energy (BLE) Central Plugin",
   "cordova": {

--- a/src/android/BLECentralPlugin.java
+++ b/src/android/BLECentralPlugin.java
@@ -50,6 +50,7 @@ public class BLECentralPlugin extends CordovaPlugin implements BluetoothAdapter.
 
     private static final String LIST = "list";
 
+    private static final String UPDATE_CONNECT_LISTENER = "updateConnectListener";
     private static final String CONNECT = "connect";
     private static final String DISCONNECT = "disconnect";
 
@@ -147,6 +148,12 @@ public class BLECentralPlugin extends CordovaPlugin implements BluetoothAdapter.
 
             listKnownDevices(callbackContext);
 
+        } else if (action.equals(UPDATE_CONNECT_LISTENER)) {
+            
+            String macAddress = args.getString(0);
+            Peripheral peripheral = peripherals.get(macAddress);
+            peripheral.updateConnectListener(callbackContext);
+            
         } else if (action.equals(CONNECT)) {
 
             String macAddress = args.getString(0);

--- a/src/android/Peripheral.java
+++ b/src/android/Peripheral.java
@@ -181,6 +181,10 @@ public class Peripheral extends BluetoothGattCallback {
         return object;
     }
 
+    public void updateConnectListener(CallbackContext callbackContext) {
+        connectCallback = callbackContext;
+    }
+
     public boolean isConnected() {
         return connected;
     }

--- a/src/ios/BLECentralPlugin.h
+++ b/src/ios/BLECentralPlugin.h
@@ -44,6 +44,7 @@
 - (void)startScanWithOptions:(CDVInvokedUrlCommand *)command;
 - (void)stopScan:(CDVInvokedUrlCommand *)command;
 
+- (void)updateConnectListener:(CDVInvokedUrlCommand *)command;
 - (void)connect:(CDVInvokedUrlCommand *)command;
 - (void)disconnect:(CDVInvokedUrlCommand *)command;
 

--- a/src/ios/BLECentralPlugin.m
+++ b/src/ios/BLECentralPlugin.m
@@ -60,6 +60,14 @@
 
 #pragma mark - Cordova Plugin Methods
 
+- (void)updateConnectListener:(CDVInvokedUrlCommand *)command {
+    
+    NSString *uuid = [command.arguments objectAtIndex:0];
+    CBPeripheral *peripheral = [self findPeripheralByUUID:uuid];
+    [connectCallbacks setObject:[command.callbackId copy] forKey:[peripheral uuidAsString]];
+    
+}
+
 - (void)connect:(CDVInvokedUrlCommand *)command {
 
     NSLog(@"connect");

--- a/www/ble.js
+++ b/www/ble.js
@@ -82,6 +82,10 @@ module.exports = {
     list: function (success, failure) {
         cordova.exec(success, failure, 'BLE', 'list', []);
     },
+    
+    updateConnectListener: function(device_id, success, failure) {
+        cordova.exec(success, failure, 'BLE', 'updateConnectListener', [device_id]);
+    },
 
     connect: function (device_id, success, failure) {
         var successWrapper = function(peripheral) {
@@ -170,6 +174,7 @@ module.exports.withPromises = {
     connect: module.exports.connect,
     startNotification: module.exports.startNotification,
     startStateNotifications: module.exports.startStateNotifications,
+    updateConnectListener: module.exports.updateConnectListener,
 
     stopScan: function() {
         return new Promise(function(resolve, reject) {


### PR DESCRIPTION
I ran into problems after connecting to a BLE device and then going to other screens in the app. After going to other screens in the app the listener for connection state with a BLE device was lost. I added the ability to update the connection listener so the app can be notified of BLE connection changes no matter where they are in the app.