### PR TITLE
Prevents scan from removing connecting Peripherals on Android

### DIFF
--- a/src/android/BLECentralPlugin.java
+++ b/src/android/BLECentralPlugin.java
@@ -41,7 +41,6 @@ import org.json.JSONException;
 import java.util.*;
 
 public class BLECentralPlugin extends CordovaPlugin implements BluetoothAdapter.LeScanCallback {
-
     // actions
     private static final String SCAN = "scan";
     private static final String START_SCAN = "startScan";
@@ -114,7 +113,6 @@ public class BLECentralPlugin extends CordovaPlugin implements BluetoothAdapter.
 
     @Override
     public boolean execute(String action, CordovaArgs args, CallbackContext callbackContext) throws JSONException {
-
         LOG.d(TAG, "action = " + action);
 
         if (bluetoothAdapter == null) {
@@ -329,7 +327,6 @@ public class BLECentralPlugin extends CordovaPlugin implements BluetoothAdapter.
     }
 
     private void connect(CallbackContext callbackContext, String macAddress) {
-
         Peripheral peripheral = peripherals.get(macAddress);
         if (peripheral != null) {
             peripheral.connect(callbackContext, cordova.getActivity());
@@ -454,7 +451,12 @@ public class BLECentralPlugin extends CordovaPlugin implements BluetoothAdapter.
         // clear non-connected cached peripherals
         for(Iterator<Map.Entry<String, Peripheral>> iterator = peripherals.entrySet().iterator(); iterator.hasNext(); ) {
             Map.Entry<String, Peripheral> entry = iterator.next();
-            if(!entry.getValue().isConnected()) {
+            Peripheral device = entry.getValue();
+            boolean connecting = device.isConnecting();
+            if (connecting){
+                LOG.d(TAG, "Not removing connecting device: " + device.getDevice().getAddress());
+            }
+            if(!entry.getValue().isConnected() && !connecting) {
                 iterator.remove();
             }
         }

--- a/src/android/Peripheral.java
+++ b/src/android/Peripheral.java
@@ -43,6 +43,7 @@ public class Peripheral extends BluetoothGattCallback {
     private byte[] advertisingData;
     private int advertisingRSSI;
     private boolean connected = false;
+    private boolean connecting = false;
     private ConcurrentLinkedQueue<BLECommand> commandQueue = new ConcurrentLinkedQueue<BLECommand>();
     private boolean bleProcessing;
 
@@ -64,6 +65,8 @@ public class Peripheral extends BluetoothGattCallback {
 
     public void connect(CallbackContext callbackContext, Activity activity) {
         BluetoothDevice device = getDevice();
+        connecting = true;
+
         connectCallback = callbackContext;
         if (Build.VERSION.SDK_INT < 23) {
             gatt = device.connectGatt(activity, false, this);
@@ -79,6 +82,8 @@ public class Peripheral extends BluetoothGattCallback {
     public void disconnect() {
         connectCallback = null;
         connected = false;
+        connecting = false;
+
         if (gatt != null) {
             gatt.disconnect();
             gatt.close();
@@ -185,6 +190,10 @@ public class Peripheral extends BluetoothGattCallback {
         return connected;
     }
 
+    public boolean isConnecting() {
+        return connecting;
+    }
+
     public BluetoothDevice getDevice() {
         return device;
     }
@@ -212,6 +221,7 @@ public class Peripheral extends BluetoothGattCallback {
         if (newState == BluetoothGatt.STATE_CONNECTED) {
 
             connected = true;
+            connecting = false;
             gatt.discoverServices();
 
         } else {


### PR DESCRIPTION
Prior to these changes, the plugin would dismiss Peripherals that were connecting (i.e. not yet connected) when it initiated a scan. This resulted in devices that were connected to the phone, but invisible to any methods in the library.  