### PR TITLE
Use same characteristic uuid with different service in iOS

### DIFF
--- a/src/ios/BLECentralPlugin.m
+++ b/src/ios/BLECentralPlugin.m
@@ -547,7 +547,10 @@
         NSData *data = characteristic.value; // send RAW data to Javascript
 
         CDVPluginResult *pluginResult = nil;
-        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsArrayBuffer:data];
+        if (data == nil)
+            pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR];
+        else
+            pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsArrayBuffer:data];
         [self.commandDelegate sendPluginResult:pluginResult callbackId:readCallbackId];
 
         [readCallbacks removeObjectForKey:key];

--- a/src/ios/BLECentralPlugin.m
+++ b/src/ios/BLECentralPlugin.m
@@ -790,7 +790,7 @@
 }
 
 -(NSString *) keyForPeripheral: (CBPeripheral *)peripheral andCharacteristic:(CBCharacteristic *)characteristic {
-    return [NSString stringWithFormat:@"%@|%@", [peripheral uuidAsString], [characteristic UUID]];
+    return [NSString stringWithFormat:@"%@|%@|%@", [peripheral uuidAsString], [characteristic.service UUID], [characteristic UUID]];
 }
 
 #pragma mark - util


### PR DESCRIPTION
If I subscribe for notification to the same characteristic's uuid but of two different services, Android is notified property,  iOS notifies the last recorded callback and not the correct one.

The problem is how the keys are stored in the dictionary (method: ```-(NSString *) keyForPeripheral: (CBPeripheral *)peripheral andCharacteristic:(CBCharacteristic *)characteristic``` )
because the key is composed from peripheral's uuid and characteristic's uuid, adding the service's uuid in the key, the problem is solved.