### PR TITLE
Remove pending stopNotificationCallback

### DIFF
--- a/src/ios/BLECentralPlugin.m
+++ b/src/ios/BLECentralPlugin.m
@@ -186,6 +186,7 @@
         NSString *key = [self keyForPeripheral: peripheral andCharacteristic:characteristic];
         NSString *callback = [command.callbackId copy];
         [notificationCallbacks setObject: callback forKey: key];
+        [stopNotificationCallbacks removeObjectForKey:key];
 
         [peripheral setNotifyValue:YES forCharacteristic:characteristic];
 


### PR DESCRIPTION
We should remove pending stopNotificationCallback when already startNotification requested