### PR TITLE
Fix duplicate symbol when using with with cordova-plugin-ble-peripheral

### DIFF
--- a/src/ios/CBPeripheral+Extensions.m
+++ b/src/ios/CBPeripheral+Extensions.m
@@ -21,6 +21,13 @@
 static char ADVERTISING_IDENTIFER;
 static char ADVERTISEMENT_RSSI_IDENTIFER;
 
+static NSDictionary *dataToArrayBuffer(NSData* data) {
+    return @{
+             @"CDVType" : @"ArrayBuffer",
+             @"data" :[data base64EncodedStringWithOptions:0]
+             };
+}
+
 @implementation CBPeripheral(com_megster_ble_extension)
 
 -(NSString *)uuidAsString {
@@ -251,16 +258,6 @@ static char ADVERTISEMENT_RSSI_IDENTIFER;
 
     return props;
 }
-
-// Borrowed from Cordova messageFromArrayBuffer since Cordova doesn't handle NSData in NSDictionary
-id dataToArrayBuffer(NSData* data)
-{
-    return @{
-             @"CDVType" : @"ArrayBuffer",
-             @"data" :[data base64EncodedStringWithOptions:0]
-             };
-}
-
 
 -(void)setAdvertising:(NSDictionary *)newAdvertisingValue{
     objc_setAssociatedObject(self, &ADVERTISING_IDENTIFER, newAdvertisingValue, OBJC_ASSOCIATION_RETAIN_NONATOMIC);


### PR DESCRIPTION
In order to avoid https://github.com/don/cordova-plugin-ble-peripheral/issues/1 it's better to have the C function declared as static