### PR TITLE
handle errors in didUpdateValueForCharacteristic

### DIFF
--- a/src/ios/BLECentralPlugin.m
+++ b/src/ios/BLECentralPlugin.m
@@ -545,9 +545,16 @@
 
     if(readCallbackId) {
         NSData *data = characteristic.value; // send RAW data to Javascript
-
         CDVPluginResult *pluginResult = nil;
-        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsArrayBuffer:data];
+        
+        // Handle Error like didWriteValueForCharacteristic does
+		if (error) {
+			NSLog(@"%@", error);
+			pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:[error localizedDescription]];
+		} else {
+			pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsArrayBuffer:data];
+		}
+        
         [self.commandDelegate sendPluginResult:pluginResult callbackId:readCallbackId];
 
         [readCallbacks removeObjectForKey:key];


### PR DESCRIPTION
handle read callback errors just like didWriteValueForCharacteristic to prevent the following exception:
 *** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '*** -[__NSPlaceholderDictionary initWithObjects:forKeys:count:]: attempt to insert nil object from objects[1]'