### PR TITLE
Fixed crash on iOS when permission to read characteristic value is denied

### DIFF
--- a/src/ios/BLECentralPlugin.m
+++ b/src/ios/BLECentralPlugin.m
@@ -627,7 +627,7 @@
                 messageAsString:[error localizedDescription]];
         } else {
             pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK
-                messageAsInt: [rssi integerValue]];
+                messageAsInt: (int) [rssi integerValue]];
         }
         [self.commandDelegate sendPluginResult:pluginResult callbackId: readRSSICallbackId];
         [readRSSICallbacks removeObjectForKey:readRSSICallbackId];
@@ -698,8 +698,8 @@
 {
     char b1[16];
     char b2[16];
-    [UUID1.data getBytes:b1];
-    [UUID2.data getBytes:b2];
+    [UUID1.data getBytes:b1 length:16];
+    [UUID2.data getBytes:b2 length:16];
 
     if (memcmp(b1, b2, UUID1.data.length) == 0)
         return 1;

--- a/src/ios/BLECentralPlugin.m
+++ b/src/ios/BLECentralPlugin.m
@@ -543,11 +543,17 @@
 
     NSString *readCallbackId = [readCallbacks objectForKey:key];
 
-    if(readCallbackId) {
+    if (readCallbackId) {
         NSData *data = characteristic.value; // send RAW data to Javascript
 
         CDVPluginResult *pluginResult = nil;
-        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsArrayBuffer:data];
+        if (data) {
+            pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsArrayBuffer:data];
+        }
+        else {
+            NSLog(@"characteristic.value == nil in didUpdateValueForCharacteristic");
+            pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR];
+        }
         [self.commandDelegate sendPluginResult:pluginResult callbackId:readCallbackId];
 
         [readCallbacks removeObjectForKey:key];


### PR DESCRIPTION
I recently ran into a crash on my testing device (iPod touch with iOS 10.3.2). I have a peripheral that, when you connect to it but are not bonded, lets you see the GATT characteristics but not retrieve or alter their values. Under this circumstance, when trying to read a value, the characteristic argument passed to didUpdateValueForCharacteristic is nil, and messageFromArrayBuffer crashes with a null pointer dereference. I added a check for this that appears to do the right thing, and also fixed a couple of warnings. I'm a rank amateur at ObjC (my background is C/C++ and JS), as well as the inner workings of Cordova, so I apologize in advance for any poor style or semantic errors.