### PR TITLE
Fixed deprecated iOS CBPeripheral RSSI calls and build warning

### DIFF
--- a/src/ios/BLECentralPlugin.m
+++ b/src/ios/BLECentralPlugin.m
@@ -622,15 +622,11 @@
     }
 
 }
-
-- (void)peripheralDidUpdateRSSI:(CBPeripheral*)peripheral error:(NSError*)error {
-    [self peripheral: peripheral didReadRSSI: [peripheral RSSI] error: error];
-}
-
 - (void)peripheral:(CBPeripheral*)peripheral didReadRSSI:(NSNumber*)rssi error:(NSError*)error {
     NSLog(@"didReadRSSI %@", rssi);
     NSString *key = [peripheral uuidAsString];
     NSString *readRSSICallbackId = [readRSSICallbacks objectForKey: key];
+    [peripheral setSavedRSSI:rssi];
     if (readRSSICallbackId) {
         CDVPluginResult* pluginResult = nil;
         if (error) {
@@ -640,7 +636,7 @@
                 messageAsString:[error localizedDescription]];
         } else {
             pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK
-                messageAsInt: [rssi integerValue]];
+                messageAsInt: (int) [rssi integerValue]];
         }
         [self.commandDelegate sendPluginResult:pluginResult callbackId: readRSSICallbackId];
         [readRSSICallbacks removeObjectForKey:readRSSICallbackId];
@@ -711,8 +707,8 @@
 {
     char b1[16];
     char b2[16];
-    [UUID1.data getBytes:b1];
-    [UUID2.data getBytes:b2];
+    [UUID1.data getBytes:b1 length:16];
+    [UUID2.data getBytes:b2 length:16];
 
     if (memcmp(b1, b2, UUID1.data.length) == 0)
         return 1;

--- a/src/ios/BLECentralPlugin.m
+++ b/src/ios/BLECentralPlugin.m
@@ -32,7 +32,6 @@
 @synthesize peripherals;
 
 - (void)pluginInitialize {
-
     NSLog(@"Cordova BLE Central Plugin");
     NSLog(@"(c)2014-2016 Don Coleman");
 
@@ -61,7 +60,6 @@
 #pragma mark - Cordova Plugin Methods
 
 - (void)connect:(CDVInvokedUrlCommand *)command {
-
     NSLog(@"connect");
     NSString *uuid = [command.arguments objectAtIndex:0];
 
@@ -72,7 +70,6 @@
 
         [connectCallbacks setObject:[command.callbackId copy] forKey:[peripheral uuidAsString]];
         [manager connectPeripheral:peripheral options:nil];
-
     } else {
         NSString *error = [NSString stringWithFormat:@"Could not find peripheral %@.", uuid];
         NSLog(@"%@", error);
@@ -107,7 +104,6 @@
 
     BLECommandContext *context = [self getData:command prop:CBCharacteristicPropertyRead];
     if (context) {
-
         CBPeripheral *peripheral = [context peripheral];
         CBCharacteristic *characteristic = [context characteristic];
 
@@ -116,18 +112,14 @@
 
         [peripheral readValueForCharacteristic:characteristic];  // callback sends value
     }
-
 }
 
 // write: function (device_id, service_uuid, characteristic_uuid, value, success, failure) {
 - (void)write:(CDVInvokedUrlCommand*)command {
-
     BLECommandContext *context = [self getData:command prop:CBCharacteristicPropertyWrite];
     NSData *message = [command.arguments objectAtIndex:3]; // This is binary
     if (context) {
-
         if (message != nil) {
-
             CBPeripheral *peripheral = [context peripheral];
             CBCharacteristic *characteristic = [context characteristic];
 
@@ -138,14 +130,12 @@
             [peripheral writeValue:message forCharacteristic:characteristic type:CBCharacteristicWriteWithResponse];
 
             // response is sent from didWriteValueForCharacteristic
-
         } else {
             CDVPluginResult *pluginResult = nil;
             pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"message was null"];
             [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
         }
     }
-
 }
 
 // writeWithoutResponse: function (device_id, service_uuid, characteristic_uuid, value, success, failure) {
@@ -212,11 +202,9 @@
         // callback sent from peripheral:didUpdateNotificationStateForCharacteristic:error:
 
     }
-
 }
 
 - (void)isEnabled:(CDVInvokedUrlCommand*)command {
-
     CDVPluginResult *pluginResult = nil;
     int bluetoothState = [manager state];
 
@@ -231,7 +219,6 @@
 }
 
 - (void)scan:(CDVInvokedUrlCommand*)command {
-
     NSLog(@"scan");
     discoverPeripherialCallbackId = [command.callbackId copy];
 
@@ -251,11 +238,9 @@
                                    selector:@selector(stopScanTimer:)
                                    userInfo:[command.callbackId copy]
                                     repeats:NO];
-
 }
 
 - (void)startScan:(CDVInvokedUrlCommand*)command {
-
     NSLog(@"startScan");
     discoverPeripherialCallbackId = [command.callbackId copy];
     NSArray *serviceUUIDStrings = [command.arguments objectAtIndex:0];
@@ -267,7 +252,6 @@
     }
 
     [manager scanForPeripheralsWithServices:serviceUUIDs options:nil];
-
 }
 
 - (void)startScanWithOptions:(CDVInvokedUrlCommand*)command {
@@ -293,7 +277,6 @@
 }
 
 - (void)stopScan:(CDVInvokedUrlCommand*)command {
-
     NSLog(@"stopScan");
 
     [manager stopScan];
@@ -304,12 +287,10 @@
 
     CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
     [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
-
 }
 
 
 - (void)isConnected:(CDVInvokedUrlCommand*)command {
-
     CDVPluginResult *pluginResult = nil;
     CBPeripheral *peripheral = [self findPeripheralByUUID:[command.arguments objectAtIndex:0]];
 
@@ -400,7 +381,6 @@
         [pluginResult setKeepCallbackAsBool:TRUE];
         [self.commandDelegate sendPluginResult:pluginResult callbackId:discoverPeripherialCallbackId];
     }
-
 }
 
 - (void)centralManagerDidUpdateState:(CBCentralManager *)central
@@ -432,7 +412,6 @@
 }
 
 - (void)centralManager:(CBCentralManager *)central didConnectPeripheral:(CBPeripheral *)peripheral {
-
     NSLog(@"didConnectPeripheral");
 
     peripheral.delegate = self;
@@ -444,7 +423,6 @@
 }
 
 - (void)centralManager:(CBCentralManager *)central didDisconnectPeripheral:(CBPeripheral *)peripheral error:(NSError *)error {
-
     NSLog(@"didDisconnectPeripheral");
 
     NSString *connectCallbackId = [connectCallbacks valueForKey:[peripheral uuidAsString]];
@@ -468,11 +446,9 @@
         pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsDictionary:dict];
         [self.commandDelegate sendPluginResult:pluginResult callbackId:connectCallbackId];
     }
-
 }
 
 - (void)centralManager:(CBCentralManager *)central didFailToConnectPeripheral:(CBPeripheral *)peripheral error:(NSError *)error {
-
     NSLog(@"didFailToConnectPeripheral");
 
     NSString *connectCallbackId = [connectCallbacks valueForKey:[peripheral uuidAsString]];
@@ -481,13 +457,11 @@
     CDVPluginResult *pluginResult = nil;
     pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsDictionary:[peripheral asDictionary]];
     [self.commandDelegate sendPluginResult:pluginResult callbackId:connectCallbackId];
-
 }
 
 #pragma mark CBPeripheralDelegate
 
 - (void)peripheral:(CBPeripheral *)peripheral didDiscoverServices:(NSError *)error {
-
     NSLog(@"didDiscoverServices");
 
     // save the services to tell when all characteristics have been discovered
@@ -501,7 +475,6 @@
 }
 
 - (void)peripheral:(CBPeripheral *)peripheral didDiscoverCharacteristicsForService:(CBService *)service error:(NSError *)error {
-
     NSLog(@"didDiscoverCharacteristicsForService");
 
     NSString *peripheralUUIDString = [peripheral uuidAsString];
@@ -524,7 +497,6 @@
     for (CBCharacteristic *characteristic in service.characteristics) {
         NSLog(@"Characteristic %@", characteristic);
     }
-
 }
 
 - (void)peripheral:(CBPeripheral *)peripheral didUpdateValueForCharacteristic:(CBCharacteristic *)characteristic error:(NSError *)error {
@@ -568,7 +540,6 @@
 }
 
 - (void)peripheral:(CBPeripheral *)peripheral didUpdateNotificationStateForCharacteristic:(CBCharacteristic *)characteristic error:(NSError *)error {
-
     NSString *key = [self keyForPeripheral: peripheral andCharacteristic:characteristic];
     NSString *notificationCallbackId = [notificationCallbacks objectForKey:key];
     NSString *stopNotificationCallbackId = [stopNotificationCallbacks objectForKey:key];
@@ -579,7 +550,6 @@
     // we only call the notificationCallbackId on errors and if there is no stopNotificationCallbackId
 
     if (stopNotificationCallbackId) {
-
         if (error) {
             NSLog(@"%@", error);
             pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:[error localizedDescription]];
@@ -596,7 +566,6 @@
         pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:[error localizedDescription]];
         [self.commandDelegate sendPluginResult:pluginResult callbackId:notificationCallbackId];
     }
-
 }
 
 
@@ -622,6 +591,7 @@
     }
 
 }
+
 - (void)peripheral:(CBPeripheral*)peripheral didReadRSSI:(NSNumber*)rssi error:(NSError*)error {
     NSLog(@"didReadRSSI %@", rssi);
     NSString *key = [peripheral uuidAsString];
@@ -646,7 +616,6 @@
 #pragma mark - internal implemetation
 
 - (CBPeripheral*)findPeripheralByUUID:(NSString*)uuid {
-
     CBPeripheral *peripheral = nil;
 
     for (CBPeripheral *p in peripherals) {
@@ -662,10 +631,8 @@
 }
 
 // RedBearLab
--(CBService *) findServiceFromUUID:(CBUUID *)UUID p:(CBPeripheral *)p
-{
-    for(int i = 0; i < p.services.count; i++)
-    {
+-(CBService *) findServiceFromUUID:(CBUUID *)UUID p:(CBPeripheral *)p {
+    for(int i = 0; i < p.services.count; i++) {
         CBService *s = [p.services objectAtIndex:i];
         if ([self compareCBUUID:s.UUID UUID2:UUID])
             return s;
@@ -675,8 +642,7 @@
 }
 
 // Find a characteristic in service with a specific property
--(CBCharacteristic *) findCharacteristicFromUUID:(CBUUID *)UUID service:(CBService*)service prop:(CBCharacteristicProperties)prop
-{
+-(CBCharacteristic *) findCharacteristicFromUUID:(CBUUID *)UUID service:(CBService*)service prop:(CBCharacteristicProperties)prop {
     NSLog(@"Looking for %@ with properties %lu", UUID, (unsigned long)prop);
     for(int i=0; i < service.characteristics.count; i++)
     {
@@ -689,8 +655,7 @@
 }
 
 // Find a characteristic in service by UUID
--(CBCharacteristic *) findCharacteristicFromUUID:(CBUUID *)UUID service:(CBService*)service
-{
+-(CBCharacteristic *) findCharacteristicFromUUID:(CBUUID *)UUID service:(CBService*)service {
     NSLog(@"Looking for %@", UUID);
     for(int i=0; i < service.characteristics.count; i++)
     {
@@ -703,8 +668,7 @@
 }
 
 // RedBearLab
--(int) compareCBUUID:(CBUUID *) UUID1 UUID2:(CBUUID *)UUID2
-{
+-(int) compareCBUUID:(CBUUID *) UUID1 UUID2:(CBUUID *)UUID2 {
     char b1[16];
     char b2[16];
     [UUID1.data getBytes:b1 length:16];
@@ -795,7 +759,6 @@
     [context setService:service];
     [context setCharacteristic:characteristic];
     return context;
-
 }
 
 -(NSString *) keyForPeripheral: (CBPeripheral *)peripheral andCharacteristic:(CBCharacteristic *)characteristic {
@@ -804,8 +767,7 @@
 
 #pragma mark - util
 
-- (NSString*) centralManagerStateToString: (int)state
-{
+- (NSString*) centralManagerStateToString: (int)state {
     switch(state)
     {
         case CBCentralManagerStateUnknown:

--- a/src/ios/CBPeripheral+Extensions.h
+++ b/src/ios/CBPeripheral+Extensions.h
@@ -25,7 +25,7 @@
 @interface CBPeripheral(com_megster_ble_extension)
 
 @property (nonatomic, retain) NSDictionary *advertising;
-@property (nonatomic, retain) NSNumber *advertisementRSSI;
+@property (nonatomic, retain) NSNumber *savedRSSI;
 
 -(void)setAdvertisementData:(NSDictionary *)advertisementData RSSI:(NSNumber*)rssi;
 -(NSDictionary *)asDictionary;

--- a/src/ios/CBPeripheral+Extensions.m
+++ b/src/ios/CBPeripheral+Extensions.m
@@ -19,7 +19,7 @@
 #import "CBPeripheral+Extensions.h"
 
 static char ADVERTISING_IDENTIFER;
-static char ADVERTISEMENT_RSSI_IDENTIFER;
+static char SAVED_RSSI_IDENTIFER;
 
 static NSDictionary *dataToArrayBuffer(NSData* data) {
     return @{
@@ -54,10 +54,8 @@ static NSDictionary *dataToArrayBuffer(NSData* data) {
         [dictionary setObject: [self name] forKey: @"name"];
     }
 
-    if ([self RSSI]) {
-        [dictionary setObject: [self RSSI] forKey: @"rssi"];
-    } else if ([self advertisementRSSI]) {
-        [dictionary setObject: [self advertisementRSSI] forKey: @"rssi"];
+    if ([self savedRSSI]) {
+        [dictionary setObject: [self savedRSSI] forKey: @"rssi"];
     }
 
     if ([self advertising]) {
@@ -76,7 +74,7 @@ static NSDictionary *dataToArrayBuffer(NSData* data) {
 -(void)setAdvertisementData:(NSDictionary *)advertisementData RSSI:(NSNumber *)rssi{
 
     [self setAdvertising:[self serializableAdvertisementData: advertisementData]];
-    [self setAdvertisementRSSI: rssi];
+    [self setSavedRSSI: rssi];
 
 }
 
@@ -268,12 +266,12 @@ static NSDictionary *dataToArrayBuffer(NSData* data) {
 }
 
 
--(void)setAdvertisementRSSI:(NSNumber *)newAdvertisementRSSIValue {
-    objc_setAssociatedObject(self, &ADVERTISEMENT_RSSI_IDENTIFER, newAdvertisementRSSIValue, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+-(void)setSavedRSSI:(NSNumber *)newSavedRSSIValue {
+    objc_setAssociatedObject(self, &SAVED_RSSI_IDENTIFER, newSavedRSSIValue, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
 
--(NSString*)advertisementRSSI{
-    return objc_getAssociatedObject(self, &ADVERTISEMENT_RSSI_IDENTIFER);
+-(NSString*)savedRSSI{
+    return objc_getAssociatedObject(self, &SAVED_RSSI_IDENTIFER);
 }
 
 @end

--- a/src/ios/CBPeripheral+Extensions.m
+++ b/src/ios/CBPeripheral+Extensions.m
@@ -67,15 +67,12 @@ static NSDictionary *dataToArrayBuffer(NSData* data) {
     }
 
     return dictionary;
-
 }
 
 // AdvertisementData is from didDiscoverPeripheral. RFduino advertises a service name in the Mfg Data Field.
--(void)setAdvertisementData:(NSDictionary *)advertisementData RSSI:(NSNumber *)rssi{
-
+-(void)setAdvertisementData:(NSDictionary *)advertisementData RSSI:(NSNumber *)rssi {
     [self setAdvertising:[self serializableAdvertisementData: advertisementData]];
     [self setSavedRSSI: rssi];
-
 }
 
 // Translates the Advertisement Data from didDiscoverPeripheral into a structure that can be serialized as JSON
@@ -104,7 +101,6 @@ static NSDictionary *dataToArrayBuffer(NSData* data) {
 //     kCBAdvDataTxPowerLevel = 32;
 //};
 - (NSDictionary *) serializableAdvertisementData: (NSDictionary *) advertisementData {
-
     NSMutableDictionary *dict = [advertisementData mutableCopy];
 
     // Service Data is a dictionary of CBUUID and NSData
@@ -163,7 +159,6 @@ static NSDictionary *dataToArrayBuffer(NSData* data) {
 // Put the service, characteristic, and descriptor data in a format that will serialize through JSON
 // sending a list of services and a list of characteristics
 - (void) serviceAndCharacteristicInfo: (NSMutableDictionary *) info {
-
     NSMutableArray *serviceList = [NSMutableArray new];
     NSMutableArray *characteristicList = [NSMutableArray new];
 
@@ -205,7 +200,6 @@ static NSDictionary *dataToArrayBuffer(NSData* data) {
 
     [info setObject:serviceList forKey:@"services"];
     [info setObject:characteristicList forKey:@"characteristics"];
-
 }
 
 -(NSArray *) decodeCharacteristicProperties: (CBCharacteristic *) characteristic {


### PR DESCRIPTION
iOS now deprecates calling RSSI on a CBPeripheral directly (https://developer.apple.com/documentation/corebluetooth/cbperipheral/1518869-rssi), so I eliminated it in favor of using readRSSI for all cases. I combined the caching of its return value with the advertisement data so the most recent value can always be obtained.

There was also a build warning due to using getBytes without specifying a length (potential buffer overflow). I added the requisite length specifier, and also made formatting consistent throughout BLECentralPlugin.m.