### PR TITLE
Fixed connect failure just after starting discovery on Android.

### DIFF
--- a/src/android/BLECentralPlugin.java
+++ b/src/android/BLECentralPlugin.java
@@ -82,6 +82,8 @@ public class BLECentralPlugin extends CordovaPlugin implements BluetoothAdapter.
 
     // key is the MAC Address
     Map<String, Peripheral> peripherals = new LinkedHashMap<String, Peripheral>();
+    // holds peripherals from the last scan, to prevent connection failures when peripheral is around but not rediscovered yet
+    Map<String, Peripheral> prevPeripherals = new LinkedHashMap<String, Peripheral>();
 
     // scan options
     boolean reportDuplicates = false;
@@ -149,6 +151,7 @@ public class BLECentralPlugin extends CordovaPlugin implements BluetoothAdapter.
         } else if (action.equals(STOP_SCAN)) {
 
             bluetoothAdapter.stopLeScan(this);
+            clearPrevPeripherals();
             callbackContext.success();
 
         } else if (action.equals(LIST)) {
@@ -338,6 +341,13 @@ public class BLECentralPlugin extends CordovaPlugin implements BluetoothAdapter.
 
     private void connect(CallbackContext callbackContext, String macAddress) {
         Peripheral peripheral = peripherals.get(macAddress);
+        if(peripheral == null) {
+            peripheral = prevPeripherals.remove(macAddress);
+            if(peripheral != null) {
+                peripherals.put(macAddress, peripheral);
+            }
+        }
+
         if (peripheral != null) {
             peripheral.connect(callbackContext, cordova.getActivity());
         } else {
@@ -452,6 +462,13 @@ public class BLECentralPlugin extends CordovaPlugin implements BluetoothAdapter.
 
     }
 
+    private void clearPrevPeripherals() {
+        for(Iterator<Map.Entry<String, Peripheral>> iterator = prevPeripherals.entrySet().iterator(); iterator.hasNext(); ) {
+            iterator.next();
+            iterator.remove();
+        }
+    }
+
     private void findLowEnergyDevices(CallbackContext callbackContext, UUID[] serviceUUIDs, int scanSeconds) {
 
         if(!PermissionHelper.hasPermission(this, ACCESS_COARSE_LOCATION)) {
@@ -469,6 +486,7 @@ public class BLECentralPlugin extends CordovaPlugin implements BluetoothAdapter.
         }
 
         // clear non-connected cached peripherals
+        clearPrevPeripherals();
         for(Iterator<Map.Entry<String, Peripheral>> iterator = peripherals.entrySet().iterator(); iterator.hasNext(); ) {
             Map.Entry<String, Peripheral> entry = iterator.next();
             Peripheral device = entry.getValue();
@@ -478,6 +496,7 @@ public class BLECentralPlugin extends CordovaPlugin implements BluetoothAdapter.
             }
             if(!entry.getValue().isConnected() && !connecting) {
                 iterator.remove();
+                prevPeripherals.put(entry.getKey(), entry.getValue());  // save it for now
             }
         }
 
@@ -496,6 +515,7 @@ public class BLECentralPlugin extends CordovaPlugin implements BluetoothAdapter.
                 public void run() {
                     LOG.d(TAG, "Stopping Scan");
                     BLECentralPlugin.this.bluetoothAdapter.stopLeScan(BLECentralPlugin.this);
+                    clearPrevPeripherals();
                 }
             }, scanSeconds * 1000);
         }


### PR DESCRIPTION
Because the Android version of the plugin would erase the list of discovered peripherals, and checked against it before allowing a connection attempt to go to the OS, it was possible to have connects fail because discovery had just been restarted, even though the peripheral was available. I added a caching system to work around this problem.