### PR TITLE
Trapped commands that caused iOS API misuse warnings

### DIFF
--- a/src/ios/BLECentralPlugin.m
+++ b/src/ios/BLECentralPlugin.m
@@ -109,6 +109,11 @@
     if (context) {
 
         CBPeripheral *peripheral = [context peripheral];
+        if ([peripheral state] != CBPeripheralStateConnected) {
+            CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Peripheral is not connected"];
+            [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+            return;
+        }
         CBCharacteristic *characteristic = [context characteristic];
 
         NSString *key = [self keyForPeripheral: peripheral andCharacteristic:characteristic];
@@ -129,6 +134,11 @@
         if (message != nil) {
 
             CBPeripheral *peripheral = [context peripheral];
+            if ([peripheral state] != CBPeripheralStateConnected) {
+                CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Peripheral is not connected"];
+                [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+                return;
+            }
             CBCharacteristic *characteristic = [context characteristic];
 
             NSString *key = [self keyForPeripheral: peripheral andCharacteristic:characteristic];
@@ -159,6 +169,11 @@
         CDVPluginResult *pluginResult = nil;
         if (message != nil) {
             CBPeripheral *peripheral = [context peripheral];
+            if ([peripheral state] != CBPeripheralStateConnected) {
+                CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Peripheral is not connected"];
+                [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+                return;
+            }
             CBCharacteristic *characteristic = [context characteristic];
 
             // TODO need to check the max length
@@ -181,6 +196,11 @@
 
     if (context) {
         CBPeripheral *peripheral = [context peripheral];
+        if ([peripheral state] != CBPeripheralStateConnected) {
+            CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Peripheral is not connected"];
+            [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+            return;
+        }
         CBCharacteristic *characteristic = [context characteristic];
 
         NSString *key = [self keyForPeripheral: peripheral andCharacteristic:characteristic];
@@ -201,7 +221,7 @@
     BLECommandContext *context = [self getData:command prop:CBCharacteristicPropertyNotify];
 
     if (context) {
-        CBPeripheral *peripheral = [context peripheral];
+        CBPeripheral *peripheral = [context peripheral];    // FIXME is setNotifyValue:NO legal to call on a peripheral not connected?
         CBCharacteristic *characteristic = [context characteristic];
 
         NSString *key = [self keyForPeripheral: peripheral andCharacteristic:characteristic];


### PR DESCRIPTION
Issuing some commands from JS when a peripheral was disconnected would cause API misuse warnings to print to the console on iOS. I trapped these in the plugin code so that the error does not reach the OS but instead propagates back to JS properly, allowing the JS developer to fix their logic.