### PR TITLE
Fixed failure to fire callbacks on iOS when device is disconnecting

### DIFF
--- a/src/ios/BLECentralPlugin.h
+++ b/src/ios/BLECentralPlugin.h
@@ -31,6 +31,7 @@
     NSMutableDictionary *readCallbacks;
     NSMutableDictionary *writeCallbacks;
     NSMutableDictionary *notificationCallbacks;
+    NSMutableDictionary *startNotificationCallbacks;
     NSMutableDictionary *stopNotificationCallbacks;
     NSMutableDictionary *connectCallbackLatches;
     NSMutableDictionary *readRSSICallbacks;

--- a/src/ios/BLECentralPlugin.m
+++ b/src/ios/BLECentralPlugin.m
@@ -46,6 +46,7 @@
     readCallbacks = [NSMutableDictionary new];
     writeCallbacks = [NSMutableDictionary new];
     notificationCallbacks = [NSMutableDictionary new];
+    startNotificationCallbacks = [NSMutableDictionary new];
     stopNotificationCallbacks = [NSMutableDictionary new];
     bluetoothStates = [NSDictionary dictionaryWithObjectsAndKeys:
                        @"unknown", @(CBCentralManagerStateUnknown),
@@ -91,6 +92,7 @@
     CBPeripheral *peripheral = [self findPeripheralByUUID:uuid];
 
     [connectCallbacks removeObjectForKey:uuid];
+    [self cleanupOperationCallbacks:peripheral withResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Peripheral disconnected"]];
 
     if (peripheral && peripheral.state != CBPeripheralStateDisconnected) {
         [manager cancelPeripheralConnection:peripheral];
@@ -185,7 +187,7 @@
 
         NSString *key = [self keyForPeripheral: peripheral andCharacteristic:characteristic];
         NSString *callback = [command.callbackId copy];
-        [notificationCallbacks setObject: callback forKey: key];
+        [startNotificationCallbacks setObject: callback forKey: key];
         [stopNotificationCallbacks removeObjectForKey:key];
 
         [peripheral setNotifyValue:YES forCharacteristic:characteristic];
@@ -449,6 +451,7 @@
 
     NSString *connectCallbackId = [connectCallbacks valueForKey:[peripheral uuidAsString]];
     [connectCallbacks removeObjectForKey:[peripheral uuidAsString]];
+    [self cleanupOperationCallbacks:peripheral withResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Peripheral disconnected"]];
 
     if (connectCallbackId) {
 
@@ -477,6 +480,7 @@
 
     NSString *connectCallbackId = [connectCallbacks valueForKey:[peripheral uuidAsString]];
     [connectCallbacks removeObjectForKey:[peripheral uuidAsString]];
+    [self cleanupOperationCallbacks:peripheral withResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Peripheral disconnected"]];
 
     CDVPluginResult *pluginResult = nil;
     pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsDictionary:[peripheral asDictionary]];
@@ -570,7 +574,7 @@
 - (void)peripheral:(CBPeripheral *)peripheral didUpdateNotificationStateForCharacteristic:(CBCharacteristic *)characteristic error:(NSError *)error {
 
     NSString *key = [self keyForPeripheral: peripheral andCharacteristic:characteristic];
-    NSString *notificationCallbackId = [notificationCallbacks objectForKey:key];
+    NSString *startNotificationCallbackId = [startNotificationCallbacks objectForKey:key];
     NSString *stopNotificationCallbackId = [stopNotificationCallbacks objectForKey:key];
 
     CDVPluginResult *pluginResult = nil;
@@ -589,12 +593,20 @@
         [self.commandDelegate sendPluginResult:pluginResult callbackId:stopNotificationCallbackId];
         [stopNotificationCallbacks removeObjectForKey:key];
         [notificationCallbacks removeObjectForKey:key];
-
-    } else if (notificationCallbackId && error) {
-
-        NSLog(@"%@", error);
-        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:[error localizedDescription]];
-        [self.commandDelegate sendPluginResult:pluginResult callbackId:notificationCallbackId];
+        NSAssert(![startNotificationCallbacks objectForKey:key], @"%@ existed in both start and stop notification callback dicts!", key);
+    }
+    
+    if (startNotificationCallbackId) {
+        if (error) {
+            NSLog(@"%@", error);
+            pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:[error localizedDescription]];
+            [self.commandDelegate sendPluginResult:pluginResult callbackId:startNotificationCallbackId];
+            [startNotificationCallbacks removeObjectForKey:key];
+        } else {
+            // notification start succeeded, move the callback to the value notifications dict
+            [notificationCallbacks setObject:startNotificationCallbackId forKey:key];
+            [startNotificationCallbacks removeObjectForKey:key];
+        }
     }
 
 }
@@ -804,6 +816,47 @@
 
 -(NSString *) keyForPeripheral: (CBPeripheral *)peripheral andCharacteristic:(CBCharacteristic *)characteristic {
     return [NSString stringWithFormat:@"%@|%@|%@", [peripheral uuidAsString], [characteristic.service UUID], [characteristic UUID]];
+}
+
++(BOOL) isKey: (NSString *)key forPeripheral:(CBPeripheral *)peripheral {
+    NSArray *keyArray = [key componentsSeparatedByString: @"|"];
+    return [[peripheral uuidAsString] compare:keyArray[0]] == NSOrderedSame;
+}
+
+-(void) cleanupOperationCallbacks: (CBPeripheral *)peripheral withResult:(CDVPluginResult *) result {
+    for(id key in readCallbacks.allKeys) {
+        if([BLECentralPlugin isKey:key forPeripheral:peripheral]) {
+            NSString *callbackId = [readCallbacks valueForKey:key];
+            [self.commandDelegate sendPluginResult:result callbackId:callbackId];
+            [readCallbacks removeObjectForKey:key];
+            NSLog(@"Cleared read callback %@ for key %@", callbackId, key);
+        }
+    }
+    for(id key in writeCallbacks.allKeys) {
+        if([BLECentralPlugin isKey:key forPeripheral:peripheral]) {
+            NSString *callbackId = [writeCallbacks valueForKey:key];
+            [self.commandDelegate sendPluginResult:result callbackId:callbackId];
+            [writeCallbacks removeObjectForKey:key];
+            NSLog(@"Cleared write callback %@ for key %@", callbackId, key);
+        }
+    }
+    for(id key in startNotificationCallbacks.allKeys) {
+        if([BLECentralPlugin isKey:key forPeripheral:peripheral]) {
+            NSString *callbackId = [startNotificationCallbacks valueForKey:key];
+            [self.commandDelegate sendPluginResult:result callbackId:callbackId];
+            [startNotificationCallbacks removeObjectForKey:key];
+            NSLog(@"Cleared start notification callback %@ for key %@", callbackId, key);
+        }
+    }
+    for(id key in stopNotificationCallbacks.allKeys) {
+        if([BLECentralPlugin isKey:key forPeripheral:peripheral]) {
+            NSString *callbackId = [stopNotificationCallbacks valueForKey:key];
+            [self.commandDelegate sendPluginResult:result callbackId:callbackId];
+            [stopNotificationCallbacks removeObjectForKey:key];
+            NSLog(@"Cleared stop notification callback %@ for key %@", callbackId, key);
+        }
+    }
+    [notificationCallbacks removeAllObjects];
 }
 
 #pragma mark - util


### PR DESCRIPTION
When a device was disconnecting, callbacks would sometimes not fire (similar effect to the problem fixed by #447). Since iOS uses several callback dictionaries, I added a function that fires failure on all of them, to be called when a disconnect occurs.