### PR TITLE
Fixed NSInvalidArgumentException when 'undefined' passed to plugin cmds

### DIFF
--- a/src/ios/BLECentralPlugin.m
+++ b/src/ios/BLECentralPlugin.m
@@ -63,7 +63,7 @@
 - (void)connect:(CDVInvokedUrlCommand *)command {
 
     NSLog(@"connect");
-    NSString *uuid = [command.arguments objectAtIndex:0];
+    NSString *uuid = [command argumentAtIndex:0];
 
     CBPeripheral *peripheral = [self findPeripheralByUUID:uuid];
 
@@ -87,7 +87,7 @@
 - (void)disconnect:(CDVInvokedUrlCommand*)command {
     NSLog(@"disconnect");
 
-    NSString *uuid = [command.arguments objectAtIndex:0];
+    NSString *uuid = [command argumentAtIndex:0];
     CBPeripheral *peripheral = [self findPeripheralByUUID:uuid];
 
     [connectCallbacks removeObjectForKey:uuid];
@@ -123,7 +123,7 @@
 - (void)write:(CDVInvokedUrlCommand*)command {
 
     BLECommandContext *context = [self getData:command prop:CBCharacteristicPropertyWrite];
-    NSData *message = [command.arguments objectAtIndex:3]; // This is binary
+    NSData *message = [command argumentAtIndex:3]; // This is binary
     if (context) {
 
         if (message != nil) {
@@ -153,7 +153,7 @@
     NSLog(@"writeWithoutResponse");
 
     BLECommandContext *context = [self getData:command prop:CBCharacteristicPropertyWriteWithoutResponse];
-    NSData *message = [command.arguments objectAtIndex:3]; // This is binary
+    NSData *message = [command argumentAtIndex:3]; // This is binary
 
     if (context) {
         CDVPluginResult *pluginResult = nil;
@@ -235,8 +235,8 @@
     NSLog(@"scan");
     discoverPeripherialCallbackId = [command.callbackId copy];
 
-    NSArray *serviceUUIDStrings = [command.arguments objectAtIndex:0];
-    NSNumber *timeoutSeconds = [command.arguments objectAtIndex:1];
+    NSArray *serviceUUIDStrings = [command argumentAtIndex:0];
+    NSNumber *timeoutSeconds = [command argumentAtIndex:1];
     NSMutableArray *serviceUUIDs = [NSMutableArray new];
 
     for (int i = 0; i < [serviceUUIDStrings count]; i++) {
@@ -258,7 +258,7 @@
 
     NSLog(@"startScan");
     discoverPeripherialCallbackId = [command.callbackId copy];
-    NSArray *serviceUUIDStrings = [command.arguments objectAtIndex:0];
+    NSArray *serviceUUIDStrings = [command argumentAtIndex:0];
     NSMutableArray *serviceUUIDs = [NSMutableArray new];
 
     for (int i = 0; i < [serviceUUIDStrings count]; i++) {
@@ -273,7 +273,7 @@
 - (void)startScanWithOptions:(CDVInvokedUrlCommand*)command {
     NSLog(@"startScanWithOptions");
     discoverPeripherialCallbackId = [command.callbackId copy];
-    NSArray *serviceUUIDStrings = [command.arguments objectAtIndex:0];
+    NSArray *serviceUUIDStrings = [command argumentAtIndex:0];
     NSMutableArray *serviceUUIDs = [NSMutableArray new];
     NSDictionary *options = command.arguments[1];
 
@@ -311,7 +311,7 @@
 - (void)isConnected:(CDVInvokedUrlCommand*)command {
 
     CDVPluginResult *pluginResult = nil;
-    CBPeripheral *peripheral = [self findPeripheralByUUID:[command.arguments objectAtIndex:0]];
+    CBPeripheral *peripheral = [self findPeripheralByUUID:[command argumentAtIndex:0]];
 
     if (peripheral && peripheral.state == CBPeripheralStateConnected) {
         pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
@@ -358,7 +358,7 @@
 
 - (void)readRSSI:(CDVInvokedUrlCommand*)command {
     NSLog(@"readRSSI");
-    NSString *uuid = [command.arguments objectAtIndex:0];
+    NSString *uuid = [command argumentAtIndex:0];
 
     CBPeripheral *peripheral = [self findPeripheralByUUID:uuid];
 
@@ -726,9 +726,9 @@
 
     CDVPluginResult *pluginResult = nil;
 
-    NSString *deviceUUIDString = [command.arguments objectAtIndex:0];
-    NSString *serviceUUIDString = [command.arguments objectAtIndex:1];
-    NSString *characteristicUUIDString = [command.arguments objectAtIndex:2];
+    NSString *deviceUUIDString = [command argumentAtIndex:0];
+    NSString *serviceUUIDString = [command argumentAtIndex:1];
+    NSString *characteristicUUIDString = [command argumentAtIndex:2];
 
     CBUUID *serviceUUID = [CBUUID UUIDWithString:serviceUUIDString];
     CBUUID *characteristicUUID = [CBUUID UUIDWithString:characteristicUUIDString];


### PR DESCRIPTION
It was possible to cause an NSInvalidArgumentException by passing 'undefined' as an argument. Using [command argumentAtIndex] instead of [command.arguments objectAtIndex], the nil is properly passed on, so the JS developer can hopefully trace the bad argument faster.