### PR TITLE
Android cleanup

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright 2014-2016 Don Coleman
+Copyright 2014-2017 Don Coleman
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/android/BLECentralPlugin.java
+++ b/src/android/BLECentralPlugin.java
@@ -1,4 +1,4 @@
-// (c) 2014-2016 Don Coleman
+// (c) 2014-2017 Don Coleman
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/android/Peripheral.java
+++ b/src/android/Peripheral.java
@@ -81,14 +81,12 @@ public class Peripheral extends BluetoothGattCallback {
 
     public void disconnect() {
         connectCallback = null;
-        connected = false;
-        connecting = false;
 
         if (gatt != null) {
             gatt.disconnect();
-            gatt.close();
-            gatt = null;
         }
+
+        close();
     }
 
     // Closes the connection completely

--- a/src/android/Peripheral.java
+++ b/src/android/Peripheral.java
@@ -93,6 +93,14 @@ public class Peripheral extends BluetoothGattCallback {
 
     // Closes the connection completely
     public void close() {
+        connected = false;
+        connecting = false;
+        commandQueue.clear();
+
+        if (gatt != null) {
+            gatt.close();
+            gatt = null; // Needed for garbage collection
+        }
     }
 
     public JSONObject asJSONObject()  {

--- a/src/android/Peripheral.java
+++ b/src/android/Peripheral.java
@@ -91,6 +91,10 @@ public class Peripheral extends BluetoothGattCallback {
         }
     }
 
+    // Closes the connection completely
+    public void close() {
+    }
+
     public JSONObject asJSONObject()  {
 
         JSONObject json = new JSONObject();

--- a/src/android/Peripheral.java
+++ b/src/android/Peripheral.java
@@ -93,6 +93,7 @@ public class Peripheral extends BluetoothGattCallback {
     public void close() {
         connected = false;
         connecting = false;
+        bleProcessing = false;
         commandQueue.clear();
 
         if (gatt != null) {

--- a/src/ios/BLECentralPlugin.m
+++ b/src/ios/BLECentralPlugin.m
@@ -2,7 +2,7 @@
 //  BLECentralPlugin.m
 //  BLE Central Cordova Plugin
 //
-//  (c) 2104-2016 Don Coleman
+//  (c) 2014-2017 Don Coleman
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@
 - (void)pluginInitialize {
 
     NSLog(@"Cordova BLE Central Plugin");
-    NSLog(@"(c)2014-2016 Don Coleman");
+    NSLog(@"(c)2014-2017 Don Coleman");
 
     [super pluginInitialize];
 
@@ -553,14 +553,14 @@
     if(readCallbackId) {
         NSData *data = characteristic.value; // send RAW data to Javascript
         CDVPluginResult *pluginResult = nil;
-        
+
         if (error) {
             NSLog(@"%@", error);
             pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:[error localizedDescription]];
         } else {
             pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsArrayBuffer:data];
         }
-        
+
         [self.commandDelegate sendPluginResult:pluginResult callbackId:readCallbackId];
 
         [readCallbacks removeObjectForKey:key];

--- a/www/ble.js
+++ b/www/ble.js
@@ -1,4 +1,4 @@
-// (c) 2014-2016 Don Coleman
+// (c) 2014-2017 Don Coleman
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
I added a clean up function in android. I am going to use this function in a subsequent pull request where I will improve the connection / disconnection process to provide a more stable connection / disconnection.

It seems a rather alarmingly high number of hacks are necessary to make android behave correctly with BLE and I am willing to bring some of those changes into the library.

The main difference from the base fork, is that when disconnecting, we also empty the command queue. I've add some issues where some BLE commands where never fulfilled and jammed the command queue, making it impossible to send new commands to the peripheral, even after disconnection.
This fixes that issue.
Also, I upgraded the copyright years ;)