### PR TITLE
Calling stop notification callback at right time

### DIFF
--- a/src/ios/BLECentralPlugin.m
+++ b/src/ios/BLECentralPlugin.m
@@ -553,14 +553,14 @@
     if(readCallbackId) {
         NSData *data = characteristic.value; // send RAW data to Javascript
         CDVPluginResult *pluginResult = nil;
-        
+
         if (error) {
             NSLog(@"%@", error);
             pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:[error localizedDescription]];
         } else {
             pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsArrayBuffer:data];
         }
-        
+
         [self.commandDelegate sendPluginResult:pluginResult callbackId:readCallbackId];
 
         [readCallbacks removeObjectForKey:key];
@@ -578,7 +578,7 @@
     // we always call the stopNotificationCallbackId if we have a callback
     // we only call the notificationCallbackId on errors and if there is no stopNotificationCallbackId
 
-    if (stopNotificationCallbackId) {
+    if (!characteristic.isNotifying && stopNotificationCallbackId) {
 
         if (error) {
             NSLog(@"%@", error);


### PR DESCRIPTION
Without this commit, the stop notification callback would sometimes
be called when actually enabling the notifications on the peripheral
this small add-on make sure it doesn't