### PR TITLE
Updated cordova plugin compat version number

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -13,7 +13,7 @@
     <repo>https://github.com/don/cordova-plugin-ble-central.git</repo>
     <issue>https://github.com/don/cordova-plugin-ble-central/issues</issue>
 
-    <dependency id="cordova-plugin-compat" version="^1.0.0" />
+    <dependency id="cordova-plugin-compat" version="^1.2.0" />
 
     <js-module src="www/ble.js" name="ble">
         <clobbers target="ble" />


### PR DESCRIPTION
It doesn't change anything in the behavior ot he plugin, but
it allows cordova 6.3.0 to *NOT* download it (as it is already
included in the cordova lib)