### PR TITLE
Explicit handling when trying to write to a non-existing service

### DIFF
--- a/src/android/Peripheral.java
+++ b/src/android/Peripheral.java
@@ -455,6 +455,12 @@ public class Peripheral extends BluetoothGattCallback {
         }
 
         BluetoothGattService service = gatt.getService(serviceUUID);
+
+        if (service == null) {
+            callbackContext.error("Service " + serviceUUID + " not found.");
+            return;
+        }
+
         BluetoothGattCharacteristic characteristic = findReadableCharacteristic(service, characteristicUUID);
 
         if (characteristic == null) {

--- a/src/android/Peripheral.java
+++ b/src/android/Peripheral.java
@@ -532,6 +532,12 @@ public class Peripheral extends BluetoothGattCallback {
         }
 
         BluetoothGattService service = gatt.getService(serviceUUID);
+
+        if (service == null) {
+            callbackContext.error("Service " + serviceUUID + " not found.");
+            return;
+        }
+
         BluetoothGattCharacteristic characteristic = findWritableCharacteristic(service, characteristicUUID, writeType);
 
         if (characteristic == null) {


### PR DESCRIPTION
Right now when you try to write or read to a non-existing service, the plugin crashes.

I think it should return gracefully an error, like we are doing with characteristics.