### PR TITLE
Added un-scanned Peripheral concept

### DIFF
--- a/src/android/BLECentralPlugin.java
+++ b/src/android/BLECentralPlugin.java
@@ -344,7 +344,6 @@ public class BLECentralPlugin extends CordovaPlugin implements BluetoothAdapter.
 
     private void connect(CallbackContext callbackContext, String macAddress) {
         if (!peripherals.containsKey(macAddress) && BLECentralPlugin.this.bluetoothAdapter.checkBluetoothAddress(macAddress)) {
-            LOG.d(TAG, "Creating un-scanned peripheral entry for address: " + macAddress);
             BluetoothDevice device = BLECentralPlugin.this.bluetoothAdapter.getRemoteDevice(macAddress);
             Peripheral peripheral = new Peripheral(device);
             peripherals.put(macAddress, peripheral);
@@ -366,7 +365,7 @@ public class BLECentralPlugin extends CordovaPlugin implements BluetoothAdapter.
         if (peripheral == null) {
             if (BluetoothAdapter.checkBluetoothAddress(macAddress)) {
                 BluetoothDevice device = bluetoothAdapter.getRemoteDevice(macAddress);
-                peripheral = new Peripheral(device, -1 , new byte[] {});
+                peripheral = new Peripheral(device);
                 peripherals.put(device.getAddress(), peripheral);
             } else {
                 callbackContext.error(macAddress + " is not a valid MAC address.");

--- a/src/android/Peripheral.java
+++ b/src/android/Peripheral.java
@@ -39,6 +39,8 @@ public class Peripheral extends BluetoothGattCallback {
     public final static UUID CLIENT_CHARACTERISTIC_CONFIGURATION_UUID = UUIDHelper.uuidFromString("2902");
     private static final String TAG = "Peripheral";
 
+    private static final int FAKE_PERIPHERAL_RSSI = 0x7FFFFFFF;
+
     private BluetoothDevice device;
     private byte[] advertisingData;
     private int advertisingRSSI;
@@ -56,6 +58,14 @@ public class Peripheral extends BluetoothGattCallback {
     private Activity currentActivity;
 
     private Map<String, CallbackContext> notificationCallbacks = new HashMap<String, CallbackContext>();
+
+    public Peripheral(BluetoothDevice device) {
+
+        this.device = device;
+        this.advertisingRSSI = FAKE_PERIPHERAL_RSSI;
+        this.advertisingData = null;
+
+    }
 
     public Peripheral(BluetoothDevice device, int advertisingRSSI, byte[] scanRecord) {
 
@@ -109,6 +119,10 @@ public class Peripheral extends BluetoothGattCallback {
         }
     }
 
+    public boolean isUnscanned() {
+        return advertisingData == null;
+    }
+
     public JSONObject asJSONObject()  {
 
         JSONObject json = new JSONObject();
@@ -116,9 +130,13 @@ public class Peripheral extends BluetoothGattCallback {
         try {
             json.put("name", device.getName());
             json.put("id", device.getAddress()); // mac address
-            json.put("advertising", byteArrayToJSON(advertisingData));
+            if (advertisingData != null) {
+                json.put("advertising", byteArrayToJSON(advertisingData));
+            }
             // TODO real RSSI if we have it, else
-            json.put("rssi", advertisingRSSI);
+            if (advertisingRSSI != FAKE_PERIPHERAL_RSSI) {
+                json.put("rssi", advertisingRSSI);
+            }
         } catch (JSONException e) { // this shouldn't happen
             e.printStackTrace();
         }

--- a/src/android/Peripheral.java
+++ b/src/android/Peripheral.java
@@ -61,6 +61,8 @@ public class Peripheral extends BluetoothGattCallback {
 
     public Peripheral(BluetoothDevice device) {
 
+        LOG.d(TAG, "Creating un-scanned peripheral entry for address: " + device.getAddress());
+
         this.device = device;
         this.advertisingRSSI = FAKE_PERIPHERAL_RSSI;
         this.advertisingData = null;


### PR DESCRIPTION
I've implemented what we discussed on #448, and it seems to work well. It's definitely cleaner than the caching solution, and should also save some memory.

I haven't tested on your master branch, since my TS code depends on the connect promise fix I mentioned in #447. The only relevant difference I could find, though, was with auto-connect, which I modified to use the same Peripheral constructor overload.