### PR TITLE
Fixed dangling promises when reconnecting

### DIFF
--- a/src/android/Peripheral.java
+++ b/src/android/Peripheral.java
@@ -67,15 +67,15 @@ public class Peripheral extends BluetoothGattCallback {
 
     private void gattConnect() {
 
-        connected = false;
-        connecting = true;
-        queueCleanup();
-        callbackCleanup();
         if (gatt != null) {
             gatt.disconnect();
             gatt.close();
             gatt = null;
         }
+        connected = false;
+        connecting = true;
+        queueCleanup();
+        callbackCleanup();
 
         BluetoothDevice device = getDevice();
         if (Build.VERSION.SDK_INT < 23) {
@@ -101,14 +101,14 @@ public class Peripheral extends BluetoothGattCallback {
     public void disconnect() {
         connected = false;
         connecting = false;
-        queueCleanup();
-        callbackCleanup();
 
         if (gatt != null) {
             gatt.disconnect();
             gatt.close();
             gatt = null;
         }
+        queueCleanup();
+        callbackCleanup();
     }
 
     public JSONObject asJSONObject()  {

--- a/src/android/Peripheral.java
+++ b/src/android/Peripheral.java
@@ -97,10 +97,10 @@ public class Peripheral extends BluetoothGattCallback {
     }
 
     public void disconnect() {
-        connectCallback = null;
         connected = false;
         connecting = false;
         queueCleanup();
+        callbackCleanup();
 
         if (gatt != null) {
             gatt.disconnect();
@@ -649,6 +649,30 @@ public class Peripheral extends BluetoothGattCallback {
         do {
             command = commandQueue.poll();
         } while (command != null);
+    }
+
+    private void callbackCleanup() {
+        if (connectCallback != null) {
+            if (autoconnect) {
+                PluginResult result = new PluginResult(PluginResult.Status.ERROR, this.asJSONObject("Peripheral Disconnected"));
+                result.setKeepCallback(true);
+                connectCallback.sendPluginResult(result);
+            }
+            else {
+                connectCallback.error(this.asJSONObject("Peripheral Disconnected"));
+                connectCallback = null;
+            }
+        }
+        if (readCallback != null) {
+            readCallback.error(this.asJSONObject("Peripheral Disconnected"));
+            readCallback = null;
+            commandCompleted();
+        }
+        if (writeCallback != null) {
+            writeCallback.error(this.asJSONObject("Peripheral Disconnected"));
+            writeCallback = null;
+            commandCompleted();
+        }
     }
 
     // add a new command to the queue

--- a/src/android/Peripheral.java
+++ b/src/android/Peripheral.java
@@ -67,6 +67,8 @@ public class Peripheral extends BluetoothGattCallback {
 
     private void gattConnect() {
 
+        connected = false;
+        connecting = true;
         queueCleanup();
         callbackCleanup();
         if (gatt != null) {
@@ -76,7 +78,6 @@ public class Peripheral extends BluetoothGattCallback {
         }
 
         BluetoothDevice device = getDevice();
-        connecting = true;
         if (Build.VERSION.SDK_INT < 23) {
             gatt = device.connectGatt(currentActivity, autoconnect, this);
         } else {
@@ -642,9 +643,15 @@ public class Peripheral extends BluetoothGattCallback {
     private void queueCleanup() {
         bleProcessing = false;
         BLECommand command;
-        do {
+        for (;;) {
             command = commandQueue.poll();
-        } while (command != null);
+            if (command != null) {
+                command.getCallbackContext().error("Peripheral Disconnected");
+            }
+            else {
+                break;
+            }
+        }
     }
 
     private void callbackCleanup() {

--- a/src/android/Peripheral.java
+++ b/src/android/Peripheral.java
@@ -68,6 +68,7 @@ public class Peripheral extends BluetoothGattCallback {
     private void gattConnect() {
 
         queueCleanup();
+        callbackCleanup();
         if (gatt != null) {
             gatt.disconnect();
             gatt.close();
@@ -243,11 +244,6 @@ public class Peripheral extends BluetoothGattCallback {
 
         } else {
             connected = false;
-            if (connectCallback != null) {
-                PluginResult result = new PluginResult(PluginResult.Status.ERROR, this.asJSONObject("Peripheral Disconnected"));
-                result.setKeepCallback(autoconnect);
-                connectCallback.sendPluginResult(result);
-            }
             if(autoconnect) {
                 gattConnect();
             } else {
@@ -652,7 +648,7 @@ public class Peripheral extends BluetoothGattCallback {
     }
 
     private void callbackCleanup() {
-        if (connectCallback != null) {
+        if (connectCallback != null && !connecting) {
             if (autoconnect) {
                 PluginResult result = new PluginResult(PluginResult.Status.ERROR, this.asJSONObject("Peripheral Disconnected"));
                 result.setKeepCallback(true);


### PR DESCRIPTION
Since gattConnect() and JS-initiated disconnects both flush the operations queue, they should fire callbacks on any queued operations. I also realized there was a potential for a data race if a callback arrives from Android at the same time as a disconnect, so I placed the GATT disconnect call before the flush - hopefully no callbacks can come after `gatt.disconnect()`. In case I'm wrong, though, I added intrinsic locks around the accesses to `readCallback` and `writeCallback`, which should prevent any nastiness.