### PR TITLE
Fixes #580

### DIFF
--- a/src/ios/BLECentralPlugin.m
+++ b/src/ios/BLECentralPlugin.m
@@ -38,7 +38,7 @@
     [super pluginInitialize];
 
     peripherals = [NSMutableSet set];
-    manager = [[CBCentralManager alloc] initWithDelegate:self queue:nil];
+    manager = [[CBCentralManager alloc] initWithDelegate:self queue:nil options:@{CBCentralManagerOptionShowPowerAlertKey: @NO}]];
 
     connectCallbacks = [NSMutableDictionary new];
     connectCallbackLatches = [NSMutableDictionary new];


### PR DESCRIPTION
- Disables the automatic prompts within the iOS platform.
- References: [1](https://stackoverflow.com/questions/34132088/continuously-showing-turn-on-bluetooth-to-allow-app-to-connect-to-accessories), [2](https://stackoverflow.com/questions/29670768/ios-cbcentralmanager-turn-on-bluetooth-prompt-and-cbcentralmanageroptionshowpo)