### PR TITLE
show Bluetooth settings on iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -566,10 +566,6 @@ Show the Bluetooth settings on the device.
 
 Function `showBluetoothSettings` opens the Bluetooth settings for the operating systems.
 
-#### iOS
-
-`showBluetoothSettings` is not supported on iOS.
-
 ### Parameters
 
 - __success__: Success callback function [optional]

--- a/src/ios/BLECentralPlugin.h
+++ b/src/ios/BLECentralPlugin.h
@@ -24,6 +24,9 @@
 #import "BLECommandContext.h"
 #import "CBPeripheral+Extensions.h"
 
+// https://github.com/guyromb/cordova-open-native-settings/blob/master/src/ios/NativeSettings.h
+#define SYSTEM_VERSION_LESS_THAN(v) ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] == NSOrderedAscending)
+
 @interface BLECentralPlugin : CDVPlugin <CBCentralManagerDelegate, CBPeripheralDelegate> {
     NSString* discoverPeripheralCallbackId;
     NSString* stateCallbackId;
@@ -60,6 +63,8 @@
 
 - (void)startStateNotifications:(CDVInvokedUrlCommand *)command;
 - (void)stopStateNotifications:(CDVInvokedUrlCommand *)command;
+
+- (void)showBluetoothSettings:(CDVInvokedUrlCommand *)command;
 
 - (void)onReset;
 

--- a/src/ios/BLECentralPlugin.m
+++ b/src/ios/BLECentralPlugin.m
@@ -355,6 +355,25 @@
     [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
 
+- (void)showBluetoothSettings:(CDVInvokedUrlCommand *)command {
+    CDVPluginResult *pluginResult = nil;
+    NSString* urlString;
+
+	if (SYSTEM_VERSION_LESS_THAN(@"9.0")) {
+        urlString = @"App-Prefs:root=General&path=Bluetooth";
+	} else {
+        urlString = @"App-Prefs:root=Bluetooth";
+    }
+
+	if ([[UIApplication sharedApplication] openURL:[NSURL URLWithString:urlString]]) {
+        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
+	} else {
+        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR];
+	}
+
+    [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+}
+
 - (void)onReset {
     stateCallbackId = nil;
 }


### PR DESCRIPTION
Borrowed code from https://github.com/guyromb/cordova-open-native-settings

If apps start getting rejected by Apple, this will need to be removed.