### PR TITLE
Refresh Device Cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ __NOTE__: the connect failure callback will be called if the peripheral disconne
 
 ## autoConnect
 
-Establish an automatic connection to a peripheral. 
+Establish an automatic connection to a peripheral.
 
     ble.autoConnect(device_id, connectSuccess, connectFailure);
 
@@ -313,6 +313,31 @@ This function may be used to request (on Android) a larger MTU size to be able t
 - __success__: Success callback function that is invoked when the connection is successful. [optional]
 - __failure__: Error callback function, invoked when error occurs. [optional]
 
+## refreshDeviceCache
+
+refreshDeviceCache
+
+    ble.refreshDeviceCache(device_id, [success], [failure]);
+
+### Description
+
+Usually not-bonded devices are not cached. But Android ignores this rule and always caches.
+If you recognize a cache issue e.g. outdated characteristics, this method can help.
+
+**NOTE** This feature is for advanced users only! Do it on your own risk.
+For more information see #587 or check the internet.
+
+#### iOS
+
+`refreshDeviceCache` is not supported on iOS.
+
+### Parameters
+
+- __device_id__: UUID or MAC address of the peripheral
+- __success__: Success callback function that is invoked when the connection is successful. [optional]
+- __failure__: Error callback function, invoked when error occurs. [optional]
+
+
 
 ## read
 
@@ -339,7 +364,7 @@ Raw data is passed from native code to the callback as an [ArrayBuffer](#typed-a
 Retrieves an [ArrayBuffer](#typed-arrays) when reading data.
 
     // read data from a characteristic, do something with output data
-    ble.read(device_id, service_uuid, characteristic_uuid, 
+    ble.read(device_id, service_uuid, characteristic_uuid,
         function(data){
             console.log("Hooray we have data"+JSON.stringify(data));
             alert("Successfully read data from device."+JSON.stringify(data));
@@ -348,7 +373,7 @@ Retrieves an [ArrayBuffer](#typed-arrays) when reading data.
             alert("Failed to read characteristic from device.");
         }
     );
-   
+
 ## write
 
 Writes data to a characteristic.
@@ -794,9 +819,9 @@ Add a new section to config.xml
             </array>
         </config-file>
     </platform>
-    
+
 See [ble-background](https://github.com/don/ble-background) example project for more details.
-    
+
 # Testing the Plugin
 
 Tests require the [Cordova Plugin Test Framework](https://github.com/apache/cordova-plugin-test-framework)
@@ -818,7 +843,7 @@ Change the start page in `config.xml`
 Run the app on your phone
 
     cordova run android --device
-    
+
 # Nordic DFU
 
 If you need Nordic DFU capability, Tomáš Bedřich has a [fork](https://github.com/fxe-gear/cordova-plugin-ble-central) of this plugin that adds an `updateFirmware()` method that allows users to upgrade nRF5x based chips over the air. https://github.com/fxe-gear/cordova-plugin-ble-central

--- a/src/android/BLECentralPlugin.java
+++ b/src/android/BLECentralPlugin.java
@@ -55,6 +55,7 @@ public class BLECentralPlugin extends CordovaPlugin implements BluetoothAdapter.
     private static final String DISCONNECT = "disconnect";
 
     private static final String REQUEST_MTU = "requestMtu";
+    private static final String REFRESH_DEVICE_CACHE = "refreshDeviceCache";
 
     private static final String READ = "read";
     private static final String WRITE = "write";
@@ -178,6 +179,11 @@ public class BLECentralPlugin extends CordovaPlugin implements BluetoothAdapter.
             String macAddress = args.getString(0);
             int mtuValue = args.getInt(1);
             requestMtu(callbackContext, macAddress, mtuValue);
+
+        } else if (action.equals(REFRESH_DEVICE_CACHE)) {
+
+            String macAddress = args.getString(0);
+            refreshDeviceCache(callbackContext, macAddress);
 
         } else if (action.equals(READ)) {
 
@@ -402,7 +408,14 @@ public class BLECentralPlugin extends CordovaPlugin implements BluetoothAdapter.
             peripheral.requestMtu(mtuValue);
         }
         callbackContext.success();
+    }
 
+    private void refreshDeviceCache(CallbackContext callbackContext, String macAddress) {
+        Peripheral peripheral = peripherals.get(macAddress);
+        if (peripheral != null) {
+            peripheral.refreshDeviceCache();
+        }
+        callbackContext.success();
     }
 
     private void read(CallbackContext callbackContext, String macAddress, UUID serviceUUID, UUID characteristicUUID) {

--- a/src/android/Peripheral.java
+++ b/src/android/Peripheral.java
@@ -29,6 +29,8 @@ import org.json.JSONObject;
 import java.util.*;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
+import java.lang.reflect.Method;
+
 /**
  * Peripheral wraps the BluetoothDevice and provides methods to convert to JSON.
  */
@@ -169,6 +171,29 @@ public class Peripheral extends BluetoothGattCallback {
         if (gatt != null) {
             LOG.d(TAG, "requestMtu mtu=" + mtuValue);
             gatt.requestMtu(mtuValue);
+        }
+    }
+
+    /**
+     * Clears the device cache.
+     * This is sometimes necessary if the periphial changed his services / characteristics.
+     * It can help if your discovered data may outdated.
+     * NOTE This hidden refresh method is called using reflection. There is no callback on complete.
+     * This is only for advanced user. You have to know how to use this and what this do.
+     * It's a rudimentary implementation.
+     * Usually you call this method while peripheral is connected, wait a few seconds and re-connect.
+     */
+    public void refreshDeviceCache() {
+        if (gatt != null) {
+            LOG.d(TAG, "refreshDeviceCache: Invoke");
+            try {
+                final Method refresh = gatt.getClass().getMethod("refresh");
+                if (refresh != null) {
+                    refresh.invoke(gatt);
+                }
+            } catch(Exception e) {
+                LOG.d(TAG, "refreshDeviceCache: Failed");
+            }
         }
     }
 

--- a/www/ble.js
+++ b/www/ble.js
@@ -117,6 +117,10 @@ module.exports = {
         cordova.exec(success, failure, 'BLE', 'requestMtu', [device_id, mtu]);
     },
 
+    refreshDeviceCache: function(device_id, success, failure) {
+        cordova.exec(success, failure, 'BLE', 'refreshDeviceCache', [device_id]);
+    },
+
     // characteristic value comes back as ArrayBuffer in the success callback
     read: function (device_id, service_uuid, characteristic_uuid, success, failure) {
         cordova.exec(success, failure, 'BLE', 'read', [device_id, service_uuid, characteristic_uuid]);


### PR DESCRIPTION
#587 
It's a (rudimentary) implementation to clear the cache to fix the outdated services / characteristic issue.
This is for advanced users only. You have to know what you do and what this do.

Usage example: 
Call this `refreshDeviceCache` if connected and wait a few seconds (this method has no complete-callback. The success callback is always called directly after invoke). Then re-connect your device by disconnect and connect again.