### PR TITLE
Location services warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ This can be done when the plugin is installed using the BLUETOOTH_USAGE_DESCRIPT
 - [ble.startNotification](#startnotification)
 - [ble.stopNotification](#stopnotification)
 - [ble.isEnabled](#isenabled)
+- [ble.isLocationEnabled](#islocationenabled)
 - [ble.isConnected](#isconnected)
 - [ble.startStateNotifications](#startstatenotifications)
 - [ble.stopStateNotifications](#stopstatenotifications)
@@ -548,6 +549,37 @@ Function `isEnabled` calls the success callback when Bluetooth is enabled and th
         },
         function() {
             console.log("Bluetooth is *not* enabled");
+        }
+    );
+
+
+## isLocationEnabled
+
+Reports if location services are enabled.
+
+    ble.isLocationEnabled(success, failure);
+
+### Description
+
+Function `isLocationEnabled` calls the success callback when location services are enabled and the failure callback when location services are *not* enabled. On some devices, location services must be enabled in order to scan for peripherals.
+
+### Supported Platforms
+
+ * Android
+
+### Parameters
+
+- __success__: Success callback function, invoked when location services are enabled.
+- __failure__: Error callback function, invoked when location services are disabled.
+
+### Quick Example
+
+    ble.isEnabled(
+        function() {
+            console.log("location services are enabled");
+        },
+        function() {
+            console.log("location services are *not* enabled");
         }
     );
 

--- a/src/android/BLECentralPlugin.java
+++ b/src/android/BLECentralPlugin.java
@@ -552,8 +552,7 @@ public class BLECentralPlugin extends CordovaPlugin implements BluetoothAdapter.
     private void findLowEnergyDevices(CallbackContext callbackContext, UUID[] serviceUUIDs, int scanSeconds) {
 
         if (!locationServicesEnabled()) {
-            callbackContext.error("Location Services are disabled");
-            return;
+            LOG.w(TAG, "Location Services are disabled");
         }
 
         if(!PermissionHelper.hasPermission(this, ACCESS_COARSE_LOCATION)) {

--- a/src/android/BLECentralPlugin.java
+++ b/src/android/BLECentralPlugin.java
@@ -70,6 +70,7 @@ public class BLECentralPlugin extends CordovaPlugin implements BluetoothAdapter.
     private static final String STOP_NOTIFICATION = "stopNotification"; // remove characteristic notification
 
     private static final String IS_ENABLED = "isEnabled";
+    private static final String IS_LOCATION_ENABLED = "isLocationEnabled";
     private static final String IS_CONNECTED  = "isConnected";
 
     private static final String SETTINGS = "showBluetoothSettings";
@@ -239,6 +240,14 @@ public class BLECentralPlugin extends CordovaPlugin implements BluetoothAdapter.
                 callbackContext.success();
             } else {
                 callbackContext.error("Bluetooth is disabled.");
+            }
+
+        } else if (action.equals(IS_LOCATION_ENABLED)) {
+
+            if (locationServicesEnabled()) {
+                callbackContext.success();
+            } else {
+                callbackContext.error("Location services disabled.");
             }
 
         } else if (action.equals(IS_CONNECTED)) {

--- a/www/ble.js
+++ b/www/ble.js
@@ -208,6 +208,11 @@ module.exports = {
         cordova.exec(success, failure, 'BLE', 'isEnabled', []);
     },
 
+    // Android only
+    isLocationEnabled: function (success, failure) {
+        cordova.exec(success, failure, 'BLE', 'isLocationEnabled', []);
+    },
+
     enable: function (success, failure) {
         cordova.exec(success, failure, "BLE", "enable", []);
     },


### PR DESCRIPTION
This is my solution to #607; it replaces the failure that occurs when location services are disabled with a console warning, and adds an API function isLocationEnabled(). I reasoned that since some devices (such as my Kindle Fire 5th gen and @airbly's Samsung) will successfully scan for devices even with location services off, the failure can't be the correct response. However, an app still needs to have a way to tell if its empty scan results could be because of disabled location services.