### PR TITLE
Use printf of cordova for LOG, reuse pattern, improve loop

### DIFF
--- a/src/android/BLECentralPlugin.java
+++ b/src/android/BLECentralPlugin.java
@@ -120,7 +120,7 @@ public class BLECentralPlugin extends CordovaPlugin implements BluetoothAdapter.
 
     @Override
     public boolean execute(String action, CordovaArgs args, CallbackContext callbackContext) throws JSONException {
-        LOG.d(TAG, "action = " + action);
+        LOG.d(TAG, "action = %s", action);
 
         if (bluetoothAdapter == null) {
             Activity activity = cordova.getActivity();

--- a/src/android/Peripheral.java
+++ b/src/android/Peripheral.java
@@ -65,7 +65,7 @@ public class Peripheral extends BluetoothGattCallback {
 
     public Peripheral(BluetoothDevice device) {
 
-        LOG.d(TAG, "Creating un-scanned peripheral entry for address: " + device.getAddress());
+        LOG.d(TAG, "Creating un-scanned peripheral entry for address: %s", device.getAddress());
 
         this.device = device;
         this.advertisingRSSI = FAKE_PERIPHERAL_RSSI;
@@ -165,13 +165,13 @@ public class Peripheral extends BluetoothGattCallback {
 
     @Override
     public void onMtuChanged(BluetoothGatt gatt, int mtu, int status) {
-        LOG.d(TAG, "mtu=" + mtu + ", status=" + status);
+        LOG.d(TAG, "mtu=%d, status=%d", mtu, status);
         super.onMtuChanged(gatt, mtu, status);
     }
 
     public void requestMtu(int mtuValue) {
         if (gatt != null) {
-            LOG.d(TAG, "requestMtu mtu=" + mtuValue);
+            LOG.d(TAG, "requestMtu mtu=%d", mtuValue);
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
                 gatt.requestMtu(mtuValue);
             }
@@ -351,7 +351,7 @@ public class Peripheral extends BluetoothGattCallback {
                 connectCallback.sendPluginResult(result);
             }
         } else {
-            LOG.e(TAG, "Service discovery failed. status = " + status);
+            LOG.e(TAG, "Service discovery failed. status = %d", status);
             if (refreshCallback != null) {
                 refreshCallback.error(this.asJSONObject("Service discovery failed"));
                 refreshCallback = null;
@@ -385,7 +385,7 @@ public class Peripheral extends BluetoothGattCallback {
     @Override
     public void onCharacteristicChanged(BluetoothGatt gatt, BluetoothGattCharacteristic characteristic) {
         super.onCharacteristicChanged(gatt, characteristic);
-        LOG.d(TAG, "onCharacteristicChanged " + characteristic);
+        LOG.d(TAG, "onCharacteristicChanged %s", characteristic);
 
         CallbackContext callback = notificationCallbacks.get(generateHashKey(characteristic));
 
@@ -399,7 +399,7 @@ public class Peripheral extends BluetoothGattCallback {
     @Override
     public void onCharacteristicRead(BluetoothGatt gatt, BluetoothGattCharacteristic characteristic, int status) {
         super.onCharacteristicRead(gatt, characteristic, status);
-        LOG.d(TAG, "onCharacteristicRead " + characteristic);
+        LOG.d(TAG, "onCharacteristicRead %s", characteristic);
 
         synchronized(this) {
             if (readCallback != null) {
@@ -419,7 +419,7 @@ public class Peripheral extends BluetoothGattCallback {
     @Override
     public void onCharacteristicWrite(BluetoothGatt gatt, BluetoothGattCharacteristic characteristic, int status) {
         super.onCharacteristicWrite(gatt, characteristic, status);
-        LOG.d(TAG, "onCharacteristicWrite " + characteristic);
+        LOG.d(TAG, "onCharacteristicWrite %s", characteristic);
 
         synchronized(this) {
             if (writeCallback != null) {
@@ -439,7 +439,7 @@ public class Peripheral extends BluetoothGattCallback {
     @Override
     public void onDescriptorWrite(BluetoothGatt gatt, BluetoothGattDescriptor descriptor, int status) {
         super.onDescriptorWrite(gatt, descriptor, status);
-        LOG.d(TAG, "onDescriptorWrite " + descriptor);
+        LOG.d(TAG, "onDescriptorWrite %s", descriptor);
         commandCompleted();
     }
 
@@ -502,7 +502,7 @@ public class Peripheral extends BluetoothGattCallback {
                     } else if ((characteristic.getProperties() & BluetoothGattCharacteristic.PROPERTY_INDICATE) != 0) {
                         descriptor.setValue(BluetoothGattDescriptor.ENABLE_INDICATION_VALUE);
                     } else {
-                        LOG.w(TAG, "Characteristic " + characteristicUUID + " does not have NOTIFY or INDICATE property set");
+                        LOG.w(TAG, "Characteristic %s does not have NOTIFY or INDICATE property set", characteristicUUID);
                     }
 
                     if (gatt.writeDescriptor(descriptor)) {
@@ -779,15 +779,8 @@ public class Peripheral extends BluetoothGattCallback {
 
     private void queueCleanup() {
         bleProcessing = false;
-        BLECommand command;
-        for (;;) {
-            command = commandQueue.poll();
-            if (command != null) {
-                command.getCallbackContext().error("Peripheral Disconnected");
-            }
-            else {
-                break;
-            }
+        for (BLECommand command = commandQueue.poll(); command != null; command = commandQueue.poll()) {
+            command.getCallbackContext().error("Peripheral Disconnected");
         }
     }
 
@@ -808,7 +801,7 @@ public class Peripheral extends BluetoothGattCallback {
 
     // add a new command to the queue
     private void queueCommand(BLECommand command) {
-        LOG.d(TAG,"Queuing Command " + command);
+        LOG.d(TAG,"Queuing Command %s", command);
         commandQueue.add(command);
 
         PluginResult result = new PluginResult(PluginResult.Status.NO_RESULT);
@@ -836,23 +829,23 @@ public class Peripheral extends BluetoothGattCallback {
         BLECommand command = commandQueue.poll();
         if (command != null) {
             if (command.getType() == BLECommand.READ) {
-                LOG.d(TAG,"Read " + command.getCharacteristicUUID());
+                LOG.d(TAG,"Read %s", command.getCharacteristicUUID());
                 bleProcessing = true;
                 readCharacteristic(command.getCallbackContext(), command.getServiceUUID(), command.getCharacteristicUUID());
             } else if (command.getType() == BluetoothGattCharacteristic.WRITE_TYPE_DEFAULT) {
-                LOG.d(TAG,"Write " + command.getCharacteristicUUID());
+                LOG.d(TAG,"Write %s", command.getCharacteristicUUID());
                 bleProcessing = true;
                 writeCharacteristic(command.getCallbackContext(), command.getServiceUUID(), command.getCharacteristicUUID(), command.getData(), command.getType());
             } else if (command.getType() == BluetoothGattCharacteristic.WRITE_TYPE_NO_RESPONSE) {
-                LOG.d(TAG,"Write No Response " + command.getCharacteristicUUID());
+                LOG.d(TAG,"Write No Response %s", command.getCharacteristicUUID());
                 bleProcessing = true;
                 writeCharacteristic(command.getCallbackContext(), command.getServiceUUID(), command.getCharacteristicUUID(), command.getData(), command.getType());
             } else if (command.getType() == BLECommand.REGISTER_NOTIFY) {
-                LOG.d(TAG,"Register Notify " + command.getCharacteristicUUID());
+                LOG.d(TAG,"Register Notify %s", command.getCharacteristicUUID());
                 bleProcessing = true;
                 registerNotifyCallback(command.getCallbackContext(), command.getServiceUUID(), command.getCharacteristicUUID());
             } else if (command.getType() == BLECommand.REMOVE_NOTIFY) {
-                LOG.d(TAG,"Remove Notify " + command.getCharacteristicUUID());
+                LOG.d(TAG,"Remove Notify %s", command.getCharacteristicUUID());
                 bleProcessing = true;
                 removeNotifyCallback(command.getCallbackContext(), command.getServiceUUID(), command.getCharacteristicUUID());
             } else if (command.getType() == BLECommand.READ_RSSI) {
@@ -874,7 +867,7 @@ public class Peripheral extends BluetoothGattCallback {
     }
 
     private String generateHashKey(UUID serviceUUID, BluetoothGattCharacteristic characteristic) {
-        return String.valueOf(serviceUUID) + "|" + characteristic.getUuid() + "|" + characteristic.getInstanceId();
+        return serviceUUID + "|" + characteristic.getUuid() + "|" + characteristic.getInstanceId();
     }
 
 }

--- a/src/android/UUIDHelper.java
+++ b/src/android/UUIDHelper.java
@@ -22,6 +22,8 @@ public class UUIDHelper {
 
     // base UUID used to build 128 bit Bluetooth UUIDs
     public static final String UUID_BASE = "0000XXXX-0000-1000-8000-00805f9b34fb";
+    // reuse pattern
+    private static final Pattern pattern = Pattern.compile("0000(.{4})-0000-1000-8000-00805f9b34fb", Pattern.CASE_INSENSITIVE);
 
     // handle 16 and 128 bit UUIDs
     public static UUID uuidFromString(String uuid) {
@@ -35,7 +37,6 @@ public class UUIDHelper {
     // return 16 bit UUIDs where possible
     public static String uuidToString(UUID uuid) {
         String longUUID = uuid.toString();
-        Pattern pattern = Pattern.compile("0000(.{4})-0000-1000-8000-00805f9b34fb", Pattern.CASE_INSENSITIVE);
         Matcher matcher = pattern.matcher(longUUID);
         if (matcher.matches()) {
             // 16 bit UUID


### PR DESCRIPTION
Hello,

this PR contains small improvements
1. We use the printf functionality of the cordova LOG. This helps to reduce the number of created objects when the log level is warn or error. In this case all the created debug strings like "x:" + x won't be created. 
2. Reuse regex pattern. No need to create it for every call.

Sincerely
Christian 