### PR TITLE
Update to only remove the disconnected peripheral from notificationCallbacks

### DIFF
--- a/src/ios/BLECentralPlugin.m
+++ b/src/ios/BLECentralPlugin.m
@@ -893,12 +893,12 @@
             NSLog(@"Cleared stop notification callback %@ for key %@", callbackId, key);
         }
     }
-    for(id key in noticiationCallbacks.allKeys) {
+    for(id key in notificationCallbacks.allKeys) {
         if([BLECentralPlugin isKey:key forPeripheral:peripheral]) {
             NSString *callbackId = [notificationCallbacks valueForKey:key];
             [self.commandDelegate sendPluginResult:result callbackId:callbackId];
-            [notificaitonCallbacks removeObjectForKey:key]
-            NSLog(@"Cleared stop notification callback %@ for key %@", callbackId, key);
+            [notificationCallbacks removeObjectForKey:key]
+            NSLog(@"Cleared notification callback %@ for key %@", callbackId, key);
         }
     }
 }

--- a/src/ios/BLECentralPlugin.m
+++ b/src/ios/BLECentralPlugin.m
@@ -893,7 +893,14 @@
             NSLog(@"Cleared stop notification callback %@ for key %@", callbackId, key);
         }
     }
-    [notificationCallbacks removeAllObjects];
+    for(id key in noticiationCallbacks.allKeys) {
+        if([BLECentralPlugin isKey:key forPeripheral:peripheral]) {
+            NSString *callbackId = [notificationCallbacks valueForKey:key];
+            [self.commandDelegate sendPluginResult:result callbackId:callbackId];
+            [notificaitonCallbacks removeObjectForKey:key]
+            NSLog(@"Cleared stop notification callback %@ for key %@", callbackId, key);
+        }
+    }
 }
 
 #pragma mark - util

--- a/src/ios/BLECentralPlugin.m
+++ b/src/ios/BLECentralPlugin.m
@@ -897,7 +897,7 @@
         if([BLECentralPlugin isKey:key forPeripheral:peripheral]) {
             NSString *callbackId = [notificationCallbacks valueForKey:key];
             [self.commandDelegate sendPluginResult:result callbackId:callbackId];
-            [notificationCallbacks removeObjectForKey:key]
+            [notificationCallbacks removeObjectForKey:key];
             NSLog(@"Cleared notification callback %@ for key %@", callbackId, key);
         }
     }


### PR DESCRIPTION
- Remove the notification callback for only the disconnected peripheral instead of removing all of the peripherals.

Issue: When connecting to two or more peripherals on an iOS device, whenever a peripheral was disconnected, intentionally or not, cleanupOperationCallbacks() removed the specific peripheral from each of the callback dictionaries. However, in the notificationCallbacks dictionary, it was clearing all the objects, removing the other peripherals that still expected to be notifying. If the device connected to the peripherals using autoConnect(), only that peripheral that reconnected would be able to continue firing the callbacks, as the others were removed.

Fix: Remove the specified peripheral, that either disconnected or called stopNotifications(), from the notificationsCallback, leaving the peripherals' callbackId's intact.