### PR TITLE
add NSBluetoothAlwaysUsageDescription for IOS13+

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ This plugin is included in iOS and Android versions of the [PhoneGap Developer A
 
 Note that this plugin's id changed from `com.megster.cordova.ble` to `cordova-plugin-ble-central` as part of the migration from the [Cordova plugin repo](http://plugins.cordova.io/) to [npm](https://www.npmjs.com/).
 
-### iOS 10
+### iOS 13
 
-For iOS 13+, apps will crash unless they include usage description keys for the types of data they access. For Bluetooth, [NSBluetoothAlwaysUsageDescription](https://developer.apple.com/documentation/bundleresources/information_property_list/protected_resources) AND [NSLocationWhenInUseUsageDescription](https://developer.apple.com/documentation/bundleresources/information_property_list/protected_resources) must be defined.
+For iOS 13, apps will crash unless they include usage description keys for the types of data they access. For Bluetooth, [NSBluetoothAlwaysUsageDescription](https://developer.apple.com/documentation/bundleresources/information_property_list/protected_resources) AND [NSLocationWhenInUseUsageDescription](https://developer.apple.com/documentation/bundleresources/information_property_list/protected_resources) must be defined.
 
 This can be done when the plugin is installed using the BLUETOOTH_USAGE_DESCRIPTION variable.
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Note that this plugin's id changed from `com.megster.cordova.ble` to `cordova-pl
 
 ### iOS 10
 
-For iOS 13+, apps will crash unless they include usage description keys for the types of data they access. For Bluetooth, [NSBluetoothAlwaysUsageDescription](https://developer.apple.com/documentation/bundleresources/information_property_list/protected_resources) AND [NSLocationUsageDescription](https://developer.apple.com/documentation/bundleresources/information_property_list/protected_resources) must be defined.
+For iOS 13+, apps will crash unless they include usage description keys for the types of data they access. For Bluetooth, [NSBluetoothAlwaysUsageDescription](https://developer.apple.com/documentation/bundleresources/information_property_list/protected_resources) AND [NSLocationWhenInUseUsageDescription](https://developer.apple.com/documentation/bundleresources/information_property_list/protected_resources) must be defined.
 
 This can be done when the plugin is installed using the BLUETOOTH_USAGE_DESCRIPTION variable.
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Note that this plugin's id changed from `com.megster.cordova.ble` to `cordova-pl
 
 ### iOS 13
 
-For iOS 13, apps will crash unless they include usage description keys for the types of data they access. For Bluetooth, [NSBluetoothAlwaysUsageDescription](https://developer.apple.com/documentation/bundleresources/information_property_list/protected_resources) AND [NSLocationWhenInUseUsageDescription](https://developer.apple.com/documentation/bundleresources/information_property_list/protected_resources) must be defined.
+For iOS 13, apps will crash unless they include usage description keys for the types of data they access. For Bluetooth, [NSBluetoothAlwaysUsageDescription](https://developer.apple.com/documentation/bundleresources/information_property_list/protected_resources) AND [NSLocationAlwaysAndWhenInUseUsageDescription](https://developer.apple.com/documentation/bundleresources/information_property_list/protected_resources) must be defined.
 
 This can be done when the plugin is installed using the BLUETOOTH_USAGE_DESCRIPTION variable.
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Note that this plugin's id changed from `com.megster.cordova.ble` to `cordova-pl
 
 ### iOS 10
 
-For iOS 10, apps will crash unless they include usage description keys for the types of data they access. For Bluetooth, [NSBluetoothPeripheralUsageDescription](https://developer.apple.com/library/prerelease/content/documentation/General/Reference/InfoPlistKeyReference/Articles/CocoaKeys.html#//apple_ref/doc/uid/TP40009251-SW20) must be defined.
+For iOS 13+, apps will crash unless they include usage description keys for the types of data they access. For Bluetooth, [NSBluetoothAlwaysUsageDescription](https://developer.apple.com/documentation/bundleresources/information_property_list/protected_resources) AND [NSLocationUsageDescription](https://developer.apple.com/documentation/bundleresources/information_property_list/protected_resources) must be defined.
 
 This can be done when the plugin is installed using the BLUETOOTH_USAGE_DESCRIPTION variable.
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -46,7 +46,7 @@
         <config-file target="*-Info.plist" parent="NSBluetoothAlwaysUsageDescription">
             <string>$BLUETOOTH_USAGE_DESCRIPTION</string>
         </config-file>
-        <config-file target="*-Info.plist" parent="NSLocationAlwaysUsageDescription">
+        <config-file target="*-Info.plist" parent="NSLocationWhenInUseUsageDescription">
             <string>$LOCATION_USAGE_DESCRIPTION</string>
         </config-file>               
     </platform>

--- a/plugin.xml
+++ b/plugin.xml
@@ -43,6 +43,9 @@
         <config-file target="*-Info.plist" parent="NSBluetoothPeripheralUsageDescription">
             <string>$BLUETOOTH_USAGE_DESCRIPTION</string>
         </config-file>
+        <config-file target="*-Info.plist" parent="NSBluetoothAlwaysUsageDescription">
+            <string>$BLUETOOTH_USAGE_DESCRIPTION</string>
+        </config-file>        
     </platform>
 
     <platform name="android">

--- a/plugin.xml
+++ b/plugin.xml
@@ -45,7 +45,10 @@
         </config-file>
         <config-file target="*-Info.plist" parent="NSBluetoothAlwaysUsageDescription">
             <string>$BLUETOOTH_USAGE_DESCRIPTION</string>
-        </config-file>        
+        </config-file>
+        <config-file target="*-Info.plist" parent="NSLocationAlwaysUsageDescription">
+            <string>$BLUETOOTH_USAGE_DESCRIPTION</string>
+        </config-file>               
     </platform>
 
     <platform name="android">

--- a/plugin.xml
+++ b/plugin.xml
@@ -46,6 +46,7 @@
         <config-file target="*-Info.plist" parent="NSBluetoothAlwaysUsageDescription">
             <string>$BLUETOOTH_USAGE_DESCRIPTION</string>
         </config-file>
+        <preference name="LOCATION_USAGE_DESCRIPTION" default=" " />
         <config-file target="*-Info.plist" parent="NSLocationWhenInUseUsageDescription">
             <string>$LOCATION_USAGE_DESCRIPTION</string>
         </config-file>               

--- a/plugin.xml
+++ b/plugin.xml
@@ -47,7 +47,7 @@
             <string>$BLUETOOTH_USAGE_DESCRIPTION</string>
         </config-file>
         <config-file target="*-Info.plist" parent="NSLocationAlwaysUsageDescription">
-            <string>$BLUETOOTH_USAGE_DESCRIPTION</string>
+            <string>$LOCATION_USAGE_DESCRIPTION</string>
         </config-file>               
     </platform>
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -47,7 +47,7 @@
             <string>$BLUETOOTH_USAGE_DESCRIPTION</string>
         </config-file>
         <preference name="LOCATION_USAGE_DESCRIPTION" default=" " />
-        <config-file target="*-Info.plist" parent="NSLocationWhenInUseUsageDescription">
+        <config-file target="*-Info.plist" parent="NSLocationAlwaysAndWhenInUseUsageDescription">
             <string>$LOCATION_USAGE_DESCRIPTION</string>
         </config-file>               
     </platform>


### PR DESCRIPTION
nsbluetoothperipheralusagedescription is deprecated in Ios 13+
We should add NSBluetoothAlwaysUsageDescription in the plugin.xml with old $BLUETOOTH_USAGE_DESCRIPTION variable.