### PR TITLE
Add support for Androids requestConnectionPriority method

### DIFF
--- a/src/android/BLECentralPlugin.java
+++ b/src/android/BLECentralPlugin.java
@@ -59,6 +59,7 @@ public class BLECentralPlugin extends CordovaPlugin implements BluetoothAdapter.
 
     private static final String QUEUE_CLEANUP = "queueCleanup";
 
+    private static final String REQUEST_CONNECTION_PRIORITY = "requestConnectionPriority";
     private static final String REQUEST_MTU = "requestMtu";
     private static final String REFRESH_DEVICE_CACHE = "refreshDeviceCache";
 
@@ -181,11 +182,21 @@ public class BLECentralPlugin extends CordovaPlugin implements BluetoothAdapter.
 
         } else if (action.equals(QUEUE_CLEANUP)) {
 
-        String macAddress = args.getString(0);
-        queueCleanup(callbackContext, macAddress);
+            String macAddress = args.getString(0);
+            queueCleanup(callbackContext, macAddress);
 
-        }
-        else if (action.equals(REQUEST_MTU)) {
+        } else if (action.equals(REQUEST_CONNECTION_PRIORITY)) {
+
+            String macAddress = args.getString(0);
+            int connectionPriority = args.getInt(1);
+
+            if (requestConnectionPriority(callbackContext, macAddress, connectionPriority)) {
+                callbackContext.success();
+            } else {
+                callbackContext.error("Error requesting connection priority.");
+            }
+
+        } else if (action.equals(REQUEST_MTU)) {
 
             String macAddress = args.getString(0);
             int mtuValue = args.getInt(1);
@@ -455,6 +466,14 @@ public class BLECentralPlugin extends CordovaPlugin implements BluetoothAdapter.
         }
         callbackContext.success();
     }    
+
+    private boolean requestConnectionPriority(CallbackContext callbackContext, String macAddress, int connectionPriority) {
+        Peripheral peripheral = peripherals.get(macAddress);
+        if (peripheral != null) {
+            return peripheral.requestConnectionPriority(connectionPriority);
+        }
+        return false;
+    }
 
     private void requestMtu(CallbackContext callbackContext, String macAddress, int mtuValue) {
 

--- a/src/android/Peripheral.java
+++ b/src/android/Peripheral.java
@@ -169,6 +169,16 @@ public class Peripheral extends BluetoothGattCallback {
         super.onMtuChanged(gatt, mtu, status);
     }
 
+    public boolean requestConnectionPriority(int connectionPriority) {
+        if (gatt != null) {
+            LOG.d(TAG, "requestConnectionPriority connectionPriority=%d", connectionPriority);
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                return gatt.requestConnectionPriority(connectionPriority);
+            }
+        }
+        return false;
+    }
+
     public void requestMtu(int mtuValue) {
         if (gatt != null) {
             LOG.d(TAG, "requestMtu mtu=%d", mtuValue);

--- a/www/ble.js
+++ b/www/ble.js
@@ -150,6 +150,10 @@ module.exports = {
         cordova.exec(success, failure, 'BLE', 'queueCleanup', [device_id]);
     },
 
+    requestConnectionPriority: function (device_id, connectionPriority,  success, failure) {
+        cordova.exec(success, failure, 'BLE', 'requestConnectionPriority', [device_id, connectionPriority]);
+    },
+
     requestMtu: function (device_id, mtu,  success, failure) {
         cordova.exec(success, failure, 'BLE', 'requestMtu', [device_id, mtu]);
     },


### PR DESCRIPTION
I've been working on support for the [`boolean requestConnectionPriority(int connectionPriority)`](https://developer.android.com/reference/android/bluetooth/BluetoothGatt.html#requestConnectionPriority(int)) method available on Android. Is this something you would be interested in merging? If so, I could add documentation to the README.
I'm not aware of any similar feature on iOS.


One thing I am uncertain about is the `int connectionPriority` argument. What's the preferred way of dealing with constants in the plugin?
I can think of three ways:

1. In the README, refer to the Android documentation.
2. In the README, document the valid options.
3. Add the constants to the code. Something like `CONNECTION_PRIORITY_BALANCED = 0`, ... `CONNECTION_PRIORITY_LOW_POWER = 2` somewhere suitable.

Related issue: #703 