### PR TITLE
Give the user feedback after an MTU size request

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,8 +315,9 @@ requestMtu
 
 ### Description
 
-When performing a write request operation (write without response), the data sent is truncated to the MTU size.
 This function may be used to request (on Android) a larger MTU size to be able to send more data at once.
+This can be useful when performing a write request operation (write without response), the data sent is truncated to the MTU size.
+The resulting MTU size is sent to the success callback. The requested and resulting MTU sizes are not necessarily equal.
 
 ### Supported Platforms
 
@@ -326,8 +327,19 @@ This function may be used to request (on Android) a larger MTU size to be able t
 
 - __device_id__: UUID or MAC address of the peripheral
 - __mtu__: MTU size
-- __success__: Success callback function that is invoked when the connection is successful. [optional]
+- __success__: Success callback function that is invoked when the MTU size request is successful. The resulting MTU size is passed as an integer.
 - __failure__: Error callback function, invoked when error occurs. [optional]
+
+### Quick Example
+
+    ble.requestMtu(device_id, new_mtu,
+        function(mtu){
+            alert("MTU set to: " + mtu);
+        },
+        function(failure){
+            alert("Failed to request MTU.");
+        }
+    );
 
 ## refreshDeviceCache
 

--- a/src/android/BLECentralPlugin.java
+++ b/src/android/BLECentralPlugin.java
@@ -454,15 +454,18 @@ public class BLECentralPlugin extends CordovaPlugin implements BluetoothAdapter.
             peripheral.queueCleanup();
         }
         callbackContext.success();
-    }    
+    }
 
     private void requestMtu(CallbackContext callbackContext, String macAddress, int mtuValue) {
 
         Peripheral peripheral = peripherals.get(macAddress);
         if (peripheral != null) {
-            peripheral.requestMtu(mtuValue);
+            peripheral.requestMtu(callbackContext, mtuValue);
+        } else {
+            String message = "Peripheral " + macAddress + " not found.";
+            LOG.w(TAG, message);
+            callbackContext.error(message);
         }
-        callbackContext.success();
     }
 
     private void refreshDeviceCache(CallbackContext callbackContext, String macAddress, long timeoutMillis) {

--- a/src/android/Peripheral.java
+++ b/src/android/Peripheral.java
@@ -59,6 +59,7 @@ public class Peripheral extends BluetoothGattCallback {
     private CallbackContext refreshCallback;
     private CallbackContext readCallback;
     private CallbackContext writeCallback;
+    private CallbackContext requestMtuCallback;
     private Activity currentActivity;
 
     private Map<String, SequentialCallbackContext> notificationCallbacks = new HashMap<String, SequentialCallbackContext>();
@@ -165,16 +166,32 @@ public class Peripheral extends BluetoothGattCallback {
 
     @Override
     public void onMtuChanged(BluetoothGatt gatt, int mtu, int status) {
-        LOG.d(TAG, "mtu=%d, status=%d", mtu, status);
         super.onMtuChanged(gatt, mtu, status);
+        LOG.d(TAG, "mtu=%d, status=%d", mtu, status);
+
+        if (status == BluetoothGatt.GATT_SUCCESS) {
+            requestMtuCallback.success(mtu);
+        } else {
+            requestMtuCallback.error("MTU request failed");
+        }
+        requestMtuCallback = null;
     }
 
-    public void requestMtu(int mtuValue) {
-        if (gatt != null) {
-            LOG.d(TAG, "requestMtu mtu=%d", mtuValue);
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-                gatt.requestMtu(mtuValue);
-            }
+    public void requestMtu(CallbackContext callback, int mtuValue) {
+        LOG.d(TAG, "requestMtu mtu=%d", mtuValue);
+        if (gatt == null) {
+            callback.error("No GATT");
+            return;
+        }
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+            callback.error("Android version does not support requestMtu");
+            return;
+        }
+
+        if (gatt.requestMtu(mtuValue)) {
+            requestMtuCallback = callback;
+        } else {
+            callback.error("Could not initiate MTU request");
         }
     }
 


### PR DESCRIPTION
Calls success callback with actual MTU size after a successful MTU size
request.
Calls error callback when an MTU size request fails.

As discussed in #606 