### PR TITLE
document queueCleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ See Apple's documentation about [Protected Resources](https://developer.apple.co
 - [ble.connectedPeripheralsWithServices](#connectedperipheralswithservices)
 - [ble.peripheralsWithIdentifiers](#peripheralswithidentifiers)
 - [ble.bondedDevices](#bondeddevices)
+- [ble.queueCleanup](#queueCleanup)
 
 ## scan
 
@@ -820,6 +821,25 @@ Sends a list of bonded low energy peripherals to the success callback.
 ### Parameters
 
 - __success__: Success callback function, invoked with a list of peripheral objects
+- __failure__: Error callback function
+
+### Supported Platforms
+
+ * Android
+
+## queueCleanup
+
+Removes all queued up commands for android.
+
+    ble.queueCleanup(success, failure);
+
+### Description
+
+Flushes the queue of all commands (write, read, readRSSI, register notification callback, ...) to be sent.
+
+### Parameters
+
+- __success__: Success callback function
 - __failure__: Error callback function
 
 ### Supported Platforms


### PR DESCRIPTION
This plugin behaves differently on Android from iOS, if the connection drops out temporarily. 

On iOS commands (`read`, `write`, `readRSSI`, `registerNotifyCallback`, ...) are just passed through to the OS. If the connection is temporarily severed then the command(s) just doesn't get through.  
However on Android they are queued. If the callback [`commandCompleted()`](https://github.com/don/cordova-plugin-ble-central/blob/35108d43e66ccd576884daef472e8f05ffa93729/src/android/Peripheral.java#L841) is never called, then packets keep queuing up and  are executed as the connection link is restored.

That queue can be emptied and the function has been exposed to JS. This MR just documents it.