### PR TITLE
Implement L2CAP support (iOS & Android)

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,10 @@ If your app targets Android 10 (API level 29) or higher, you have also the optio
 -   [ble.peripheralsWithIdentifiers](#peripheralswithidentifiers)
 -   [ble.restoredBluetoothState](#restoredbluetoothstate)
 -   [ble.bondedDevices](#bondeddevices)
+-   [ble.l2cap.open](#l2capopen)
+-   [ble.l2cap.close](#l2capclose)
+-   [ble.l2cap.receiveData](#l2capreceivedata)
+-   [ble.l2cap.write](#l2capwrite)
 
 ## scan
 
@@ -954,6 +958,104 @@ Sends a list of bonded low energy peripherals to the success callback.
 
 -   **success**: Success callback function, invoked with a list of peripheral objects
 -   **failure**: Error callback function
+
+## l2cap.open
+
+Open an L2CAP channel with a connected peripheral. The PSM is assigned by the peripheral, or possibly defined by the Bluetooth standard.
+
+    ble.l2cap.open(device_id, psm, connectCallback, disconnectCallback);
+
+Using await with promises
+
+    await ble.withPromises.l2cap.open(device_id, psm, disconnectCallback);
+
+### Description
+
+An L2CAP channel is a duplex byte stream interface (similar to a network socket) that can be used for much more efficient binary data transfer. This is used in some streaming applications, such as the Bluetooth Object Transfer Service.
+
+The PSM (protocol/service multiplexer) is specified by the peripheral when it opens the channel. Some channels have predefined identifiers controlled by [Bluetooth organisation](https://www.bluetooth.com/specifications/assigned-numbers/logical-link-control/). Apple has also outlined a [generic design](https://developer.apple.com/documentation/corebluetooth/cbuuidl2cappsmcharacteristicstring) for PSM exchange. To advertise an L2CAP channel on a specific service, a characteristic with the UUID "ABDD3056-28FA-441D-A470-55A75A52553A" is added to that service, and updated by the peripheral when the L2CAP channel is opened.
+
+### Parameters
+
+-   **device_id**: UUID or MAC address of the peripheral
+-   **psm**: Protocol/service multiplexer, specified by the peripheral when the channel was opened
+-   **connectCallback**: Connect callback function, invoked when an L2CAP connection is successfully opened
+-   **disconnectCallback**: Disconnect callback function, invoked when the L2CAP stream closes or an error occurs.
+
+### Supported Platforms
+
+-   iOS
+
+## l2cap.close
+
+Close an L2CAP channel.
+
+    ble.l2cap.close(device_id, psm, success, failure);
+
+Using await with promises
+
+    await ble.withPromises.l2cap.close(device_id, psm);
+
+### Description
+
+Closes an open L2CAP channel with the selected device. All pending reads and writes are aborted.
+
+### Parameters
+
+-   **device_id**: UUID or MAC address of the peripheral
+-   **psm**: Protocol/service multiplexer, specified by the peripheral when the channel was opened
+-   **success**: Success callback function that is invoked when the stream is closed successfully. [optional]
+-   **failure**: Error callback function, invoked when error occurs. [optional]
+
+### Supported Platforms
+
+-   iOS
+
+## l2cap.receiveData
+
+Receive data from an L2CAP channel.
+
+    ble.l2cap.receiveData(device_id, psm, dataCallback);
+
+### Description
+
+Sets the function to be called whenever bytes are received on the L2CAP channel. This function will be used as long as the L2CAP connection remains open.
+
+### Parameters
+
+-   **device_id**: UUID or MAC address of the peripheral
+-   **psm**: Protocol/service multiplexer, specified by the peripheral when the channel was opened
+-   **dataCallback**: Data processing function that is invoked when bytes are received from the peripheral
+
+### Supported Platforms
+
+-   iOS
+
+## l2cap.write
+
+Write data to an L2CAP channel.
+
+    ble.l2cap.write(device_id, psm, data, success, failure);
+
+Using await with promises
+
+    await ble.withPromises.l2cap.write(device_id, psm, data);
+
+### Description
+
+Writes all data to an open L2CAP channel. If the data exceeds the available space in the transmit buffer, the data will be automatically sent in chunks as space becomes available. The success callback is called only once after all the supplied bytes have been written to the transmit stream.
+
+### Parameters
+
+-   **device_id**: UUID or MAC address of the peripheral
+-   **psm**: Protocol/service multiplexer, specified by the peripheral when the channel was opened
+-   **data**: Data to write to the stream
+-   **success**: Success callback function that is invoked after all bytes have been written to the stream [optional]
+-   **failure**: Error callback function, invoked when error occurs [optional]
+
+### Supported Platforms
+
+-   iOS
 
 # Peripheral Data
 

--- a/README.md
+++ b/README.md
@@ -969,6 +969,12 @@ Using await with promises
 
     await ble.withPromises.l2cap.open(device_id, psm, disconnectCallback);
 
+Android supports additional arguments in the psm flag to select whether the L2CAP channel is insecure or secure (iOS does this automatically):
+
+ble.l2cap.open(device_id, { psm: psm, secureChannel: true }, connectCallback, disconnectCallback);
+// or with promises
+await ble.withPromises.l2cap.open(device_id, { psm: psm, secureChannel: true }, disconnectCallback);
+
 ### Description
 
 An L2CAP channel is a duplex byte stream interface (similar to a network socket) that can be used for much more efficient binary data transfer. This is used in some streaming applications, such as the Bluetooth Object Transfer Service.
@@ -978,13 +984,14 @@ The PSM (protocol/service multiplexer) is specified by the peripheral when it op
 ### Parameters
 
 -   **device_id**: UUID or MAC address of the peripheral
--   **psm**: Protocol/service multiplexer, specified by the peripheral when the channel was opened
+-   **psm** or **options**: Protocol/service multiplexer, specified by the peripheral when the channel was opened. Can be an object which includes a `psm` key, with an optional `secureChannel` boolean setting to control whether the channel is encrypted or not (Android-only)
 -   **connectCallback**: Connect callback function, invoked when an L2CAP connection is successfully opened
 -   **disconnectCallback**: Disconnect callback function, invoked when the L2CAP stream closes or an error occurs.
 
 ### Supported Platforms
 
 -   iOS
+-   Android (>= 10)
 
 ## l2cap.close
 
@@ -1010,6 +1017,7 @@ Closes an open L2CAP channel with the selected device. All pending reads and wri
 ### Supported Platforms
 
 -   iOS
+-   Android (>= 10)
 
 ## l2cap.receiveData
 
@@ -1030,6 +1038,7 @@ Sets the function to be called whenever bytes are received on the L2CAP channel.
 ### Supported Platforms
 
 -   iOS
+-   Android (>= 10)
 
 ## l2cap.write
 
@@ -1056,6 +1065,7 @@ Writes all data to an open L2CAP channel. If the data exceeds the available spac
 ### Supported Platforms
 
 -   iOS
+-   Android (>= 10)
 
 # Peripheral Data
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -36,6 +36,9 @@
         <header-file src="src/ios/BLECommandContext.h" target-dir="BLECentralPlugin" />
         <source-file src="src/ios/BLECommandContext.m" target-dir="BLECentralPlugin" />
 
+        <header-file src="src/ios/BLEStreamContext.h" target-dir="BLECentralPlugin" />
+        <source-file src="src/ios/BLEStreamContext.m" target-dir="BLECentralPlugin" />
+
         <!-- frameworks -->
         <framework src="CoreBluetooth.framework" />
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -90,6 +90,8 @@
             target-dir="src/com/megster/cordova/ble/central"/>
         <source-file src="src/android/UUIDHelper.java"
             target-dir="src/com/megster/cordova/ble/central"/>
+        <source-file src="src/android/L2CAPContext.java"
+            target-dir="src/com/megster/cordova/ble/central"/>
 
     </platform>
 

--- a/src/android/BLECentralPlugin.java
+++ b/src/android/BLECentralPlugin.java
@@ -95,6 +95,11 @@ public class BLECentralPlugin extends CordovaPlugin {
     private static final String START_STATE_NOTIFICATIONS = "startStateNotifications";
     private static final String STOP_STATE_NOTIFICATIONS = "stopStateNotifications";
 
+    private static final String OPEN_L2CAP = "openL2Cap";
+    private static final String CLOSE_L2CAP = "closeL2Cap";
+    private static final String RECEIVE_L2CAP = "receiveDataL2Cap";
+    private static final String WRITE_L2CAP = "writeL2Cap";
+
     private static final String START_LOCATION_STATE_NOTIFICATIONS = "startLocationStateNotifications";
     private static final String STOP_LOCATION_STATE_NOTIFICATIONS = "stopLocationStateNotifications";
 
@@ -478,6 +483,33 @@ public class BLECentralPlugin extends CordovaPlugin {
 
             getBondedDevices(callbackContext);
 
+        } else if (action.equals(OPEN_L2CAP)) {
+
+            String macAddress = args.getString(0);
+            int psm = args.getInt(1);
+            JSONObject options = args.optJSONObject(2);
+            boolean secureChannel = options != null && options.optBoolean("secureChannel", false);
+            connectL2cap(callbackContext, macAddress, psm, secureChannel);
+
+        } else if (action.equals(CLOSE_L2CAP)) {
+
+            String macAddress = args.getString(0);
+            int psm = args.getInt(1);
+            disconnectL2cap(callbackContext, macAddress, psm);
+
+        } else if (action.equals(WRITE_L2CAP)) {
+
+            String macAddress = args.getString(0);
+            int psm = args.getInt(1);
+            byte[] data = args.getArrayBuffer(2);
+            writeL2cap(callbackContext, macAddress, psm, data);
+
+        } else if (action.equals(RECEIVE_L2CAP)) {
+
+            String macAddress = args.getString(0);
+            int psm = args.getInt(1);
+            registerL2CapReceiver(callbackContext, macAddress, psm);
+
         } else {
 
             validAction = false;
@@ -822,6 +854,63 @@ public class BLECentralPlugin extends CordovaPlugin {
 
         //peripheral.writeCharacteristic(callbackContext, serviceUUID, characteristicUUID, data, writeType);
         peripheral.queueWrite(callbackContext, serviceUUID, characteristicUUID, data, writeType);
+
+    }
+
+    private void connectL2cap(CallbackContext callbackContext, String macAddress, int psm, boolean secureChannel) {
+        Peripheral peripheral = peripherals.get(macAddress);
+        if (peripheral == null) {
+            callbackContext.error("Peripheral " + macAddress + " not found.");
+            return;
+        }
+
+        if (!peripheral.isConnected()) {
+            callbackContext.error("Peripheral " + macAddress + " is not connected.");
+            return;
+        }
+
+        peripheral.connectL2cap(callbackContext, psm, secureChannel);
+    }
+
+    private void disconnectL2cap(CallbackContext callbackContext, String macAddress, int psm) {
+
+        Peripheral peripheral = peripherals.get(macAddress);
+        if (peripheral != null) {
+            peripheral.disconnectL2Cap(callbackContext, psm);
+        }
+
+        callbackContext.success();
+
+    }
+
+    private void writeL2cap(CallbackContext callbackContext, String macAddress, int psm, byte[] data) {
+
+        Peripheral peripheral = peripherals.get(macAddress);
+
+        if (peripheral == null) {
+            callbackContext.error("Peripheral " + macAddress + " not found.");
+            return;
+        }
+
+        if (!peripheral.isL2capConnected(psm)) {
+            callbackContext.error("Peripheral " + macAddress + " L2Cap is not connected.");
+            return;
+        }
+
+        peripheral.queueL2CapWrite(callbackContext, psm, data);
+
+    }
+
+    private void registerL2CapReceiver(CallbackContext callbackContext, String macAddress, int psm) {
+
+        Peripheral peripheral = peripherals.get(macAddress);
+
+        if (peripheral == null) {
+            callbackContext.error("Peripheral " + macAddress + " not found.");
+            return;
+        }
+
+        peripheral.registerL2CapReceiver(callbackContext, psm);
 
     }
 

--- a/src/android/BLECentralPlugin.java
+++ b/src/android/BLECentralPlugin.java
@@ -897,7 +897,7 @@ public class BLECentralPlugin extends CordovaPlugin {
             return;
         }
 
-        peripheral.queueL2CapWrite(callbackContext, psm, data);
+        cordova.getThreadPool().execute(() -> peripheral.writeL2CapChannel(callbackContext, psm, data));
 
     }
 

--- a/src/android/BLECommand.java
+++ b/src/android/BLECommand.java
@@ -14,6 +14,7 @@ class BLECommand {
     public static int REGISTER_NOTIFY = 10001;
     public static int REMOVE_NOTIFY = 10002;
     public static int READ_RSSI = 10003;
+    public static int L2CAP_WRITE = 10005;
     // BluetoothGattCharacteristic.WRITE_TYPE_NO_RESPONSE
     // BluetoothGattCharacteristic.WRITE_TYPE_DEFAULT
 
@@ -22,6 +23,7 @@ class BLECommand {
     private UUID characteristicUUID;
     private byte[] data;
     private int type;
+    private int psm;
 
 
     public BLECommand(CallbackContext callbackContext, UUID serviceUUID, UUID characteristicUUID, int type) {
@@ -35,6 +37,19 @@ class BLECommand {
         this.callbackContext = callbackContext;
         this.serviceUUID = serviceUUID;
         this.characteristicUUID = characteristicUUID;
+        this.data = data;
+        this.type = type;
+    }
+
+    public BLECommand(CallbackContext callbackContext, int psm, int type) {
+        this.callbackContext = callbackContext;
+        this.psm = psm;
+        this.type = type;
+    }
+
+    public BLECommand(CallbackContext callbackContext, int psm, byte[] data, int type) {
+        this.callbackContext = callbackContext;
+        this.psm = psm;
         this.data = data;
         this.type = type;
     }
@@ -58,4 +73,6 @@ class BLECommand {
     public byte[] getData() {
         return data;
     }
+
+    public int getPSM() { return psm; }
 }

--- a/src/android/BLECommand.java
+++ b/src/android/BLECommand.java
@@ -14,7 +14,6 @@ class BLECommand {
     public static int REGISTER_NOTIFY = 10001;
     public static int REMOVE_NOTIFY = 10002;
     public static int READ_RSSI = 10003;
-    public static int L2CAP_WRITE = 10005;
     // BluetoothGattCharacteristic.WRITE_TYPE_NO_RESPONSE
     // BluetoothGattCharacteristic.WRITE_TYPE_DEFAULT
 

--- a/src/android/L2CAPContext.java
+++ b/src/android/L2CAPContext.java
@@ -1,0 +1,134 @@
+package com.megster.cordova.ble.central;
+
+import android.bluetooth.BluetoothDevice;
+import android.bluetooth.BluetoothSocket;
+import android.os.Build;
+import android.support.annotation.RequiresApi;
+
+import org.apache.cordova.CallbackContext;
+import org.apache.cordova.LOG;
+import org.apache.cordova.PluginResult;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Arrays;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+class L2CAPContext {
+    private static final String TAG = "L2CAPContext";
+
+    private final Object updateLock = new Object();
+    private final int psm;
+    private final BluetoothDevice device;
+    private final ExecutorService executor;
+
+    private BluetoothSocket socket;
+    private CallbackContext l2capReceiver;
+    private CallbackContext l2capConnectContext;
+
+    public L2CAPContext(BluetoothDevice device, int psm) {
+        this.psm = psm;
+        this.device = device;
+        this.executor = Executors.newSingleThreadExecutor();
+    }
+
+    public void connectL2cap(CallbackContext callbackContext, boolean secureChannel) {
+        try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                disconnectL2Cap();
+                socket = secureChannel ? device.createL2capChannel(psm) : device.createInsecureL2capChannel(psm);
+                socket.connect();
+                executor.submit(this::readL2CapData);
+
+                PluginResult result = new PluginResult(PluginResult.Status.OK);
+                result.setKeepCallback(true);
+                callbackContext.sendPluginResult(result);
+                synchronized (updateLock) {
+                    l2capConnectContext = callbackContext;
+                }
+            } else {
+                callbackContext.error("L2CAP not supported by platform");
+            }
+        } catch (Exception e) {
+            LOG.e(TAG, "connect L2Cap failed", e);
+            callbackContext.error("Failed to open L2Cap connection");
+        }
+    }
+
+    public void disconnectL2Cap() {
+        disconnectL2Cap("L2CAP disconnected");
+    }
+
+    public boolean isConnected() {
+        return socket != null && socket.isConnected();
+    }
+
+    private void disconnectL2Cap(String message) {
+        try {
+            if (socket != null) {
+                socket.close();
+                socket = null;
+            }
+        } catch (Exception e) {
+            LOG.e(TAG, "disconnect L2Cap failed", e);
+        }
+        CallbackContext callback;
+        synchronized (updateLock) {
+            callback = l2capConnectContext;
+            l2capConnectContext = null;
+        }
+        if (callback != null) {
+            callback.error(message);
+        }
+    }
+
+    public void registerL2CapReceiver(CallbackContext callbackContext) {
+        synchronized (updateLock) {
+            l2capReceiver = callbackContext;
+        }
+    }
+
+    public void writeL2CapChannel(CallbackContext callbackContext, byte[] data) {
+        if (socket == null || !socket.isConnected()) {
+            callbackContext.error("L2CAP PSM " + psm + " not connected.");
+            return;
+        }
+
+        try {
+            OutputStream outputStream = socket.getOutputStream();
+            outputStream.write(data);
+            callbackContext.success();
+        } catch (IOException e) {
+            LOG.e(TAG, "L2Cap write failed", e);
+            disconnectL2Cap("L2Cap write pipe broken");
+            callbackContext.error("L2CAP write failed");
+        }
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.M)
+    private void readL2CapData() {
+        try {
+            InputStream inputStream = socket.getInputStream();
+            byte[] buffer = new byte[socket.getMaxReceivePacketSize()];
+            while (socket.isConnected()) {
+                int readCount = inputStream.read(buffer);
+                CallbackContext receiver;
+                synchronized (updateLock) {
+                    receiver = l2capReceiver;
+                }
+                if (readCount >= 0 && receiver != null) {
+                    PluginResult result = new PluginResult(PluginResult.Status.OK, Arrays.copyOf(buffer, readCount));
+                    result.setKeepCallback(true);
+                    receiver.sendPluginResult(result);
+                }
+            }
+            disconnectL2Cap("L2Cap channel disconnected");
+
+        } catch (Exception e) {
+            LOG.e(TAG, "reading L2Cap data failed", e);
+            disconnectL2Cap("L2Cap read pipe broken");
+        }
+    }
+}

--- a/src/android/L2CAPContext.java
+++ b/src/android/L2CAPContext.java
@@ -3,7 +3,7 @@ package com.megster.cordova.ble.central;
 import android.bluetooth.BluetoothDevice;
 import android.bluetooth.BluetoothSocket;
 import android.os.Build;
-import android.support.annotation.RequiresApi;
+import androidx.annotation.RequiresApi;
 
 import org.apache.cordova.CallbackContext;
 import org.apache.cordova.LOG;

--- a/src/android/Peripheral.java
+++ b/src/android/Peripheral.java
@@ -775,11 +775,6 @@ public class Peripheral extends BluetoothGattCallback {
 
     }
 
-    private void writeL2CapChannel(CallbackContext callbackContext, int psm, byte[] data) {
-        getOrAddL2CAPContext(psm).writeL2CapChannel(callbackContext, data);
-        commandCompleted();
-    }
-
     // Some peripherals re-use UUIDs for multiple characteristics so we need to check the properties
     // and UUID of all characteristics instead of using service.getCharacteristic(characteristicUUID)
     private BluetoothGattCharacteristic findWritableCharacteristic(BluetoothGattService service, UUID characteristicUUID, int writeType) {
@@ -849,9 +844,9 @@ public class Peripheral extends BluetoothGattCallback {
         }
     }
 
-    public void queueL2CapWrite(CallbackContext callbackContext, int psm, byte[] data) {
-        BLECommand command = new BLECommand(callbackContext, psm, data, BLECommand.L2CAP_WRITE);
-        queueCommand(command);
+    public void writeL2CapChannel(CallbackContext callbackContext, int psm, byte[] data) {
+        LOG.d(TAG,"L2CAP Write %s", psm);
+        getOrAddL2CAPContext(psm).writeL2CapChannel(callbackContext, data);
     }
 
     private void callbackCleanup() {
@@ -914,10 +909,6 @@ public class Peripheral extends BluetoothGattCallback {
             } else if (command.getType() == BLECommand.READ_RSSI) {
                 LOG.d(TAG,"Read RSSI");
                 readRSSI(command.getCallbackContext());
-            } else if (command.getType() == BLECommand.L2CAP_WRITE) {
-                LOG.d(TAG,"L2CAP Write %s", command.getPSM());
-                bleProcessing = true;
-                writeL2CapChannel(command.getCallbackContext(), command.getPSM(), command.getData());
             } else {
                 // this shouldn't happen
                 bleProcessing.set(false);

--- a/src/ios/BLECentralPlugin.h
+++ b/src/ios/BLECentralPlugin.h
@@ -22,6 +22,7 @@
 #import <Cordova/CDV.h>
 #import <CoreBluetooth/CoreBluetooth.h>
 #import "BLECommandContext.h"
+#import "BLEStreamContext.h"
 #import "CBPeripheral+Extensions.h"
 
 @interface BLECentralPlugin : CDVPlugin <CBCentralManagerDelegate, CBPeripheralDelegate> {
@@ -36,6 +37,7 @@
     NSMutableDictionary *connectCallbackLatches;
     NSMutableDictionary *readRSSICallbacks;
     NSDictionary<NSString*,id> *restoredState;
+    NSMutableDictionary *l2CapContexts;
 }
 
 @property (strong, nonatomic) NSMutableSet *peripherals;
@@ -70,6 +72,11 @@
 - (void)readRSSI:(CDVInvokedUrlCommand *)command;
 
 - (void)restoredBluetoothState:(CDVInvokedUrlCommand *)command;
+
+- (void)closeL2Cap:(CDVInvokedUrlCommand*)command;
+- (void)openL2Cap:(CDVInvokedUrlCommand*)command;
+- (void)receiveDataL2Cap:(CDVInvokedUrlCommand*)command;
+- (void)writeL2Cap:(CDVInvokedUrlCommand*)command;
 
 @end
 

--- a/src/ios/BLECentralPlugin.m
+++ b/src/ios/BLECentralPlugin.m
@@ -61,6 +61,7 @@
     notificationCallbacks = [NSMutableDictionary new];
     startNotificationCallbacks = [NSMutableDictionary new];
     stopNotificationCallbacks = [NSMutableDictionary new];
+    l2CapContexts = [NSMutableDictionary new];
     bluetoothStates = [NSDictionary dictionaryWithObjectsAndKeys:
                        @"unknown", @(CBCentralManagerStateUnknown),
                        @"resetting", @(CBCentralManagerStateResetting),
@@ -556,6 +557,83 @@
     [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
 
+- (void)closeL2Cap:(CDVInvokedUrlCommand*)command {
+    NSLog(@"closeL2Cap");
+
+    NSString *uuid = [command argumentAtIndex:0];
+    NSNumber *psm = [command argumentAtIndex:1];
+    CBPeripheral *peripheral = [self findPeripheralByUUID:uuid];
+
+    if (peripheral) {
+        NSString *key = [self keyForPeripheral:peripheral andPSM:psm.unsignedShortValue];
+        BLEStreamContext *context = [l2CapContexts objectForKey:key];
+        if (context) {
+            [context closeWithReason:@"L2CAP channel closed"];
+            [l2CapContexts removeObjectForKey:key];
+        }
+        NSLog(@"Cleared callbacks for L2CAP channel key %@", key);
+    }
+    
+    CDVPluginResult *result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
+    [self.commandDelegate sendPluginResult:result callbackId:command.callbackId];
+}
+
+- (void)openL2Cap:(CDVInvokedUrlCommand*)command {
+    NSLog(@"openL2Cap");
+
+    NSString *uuid = [command argumentAtIndex:0];
+    NSNumber *psm = [command argumentAtIndex:1];
+    CBPeripheral *peripheral = [self findPeripheralByUUID:uuid];
+
+    if (!peripheral) {
+        NSString *message = [NSString stringWithFormat:@"Peripheral %@ not found", uuid];
+        NSLog(@"%@", message);
+        CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:message];
+        [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+
+    } else {
+        BLEStreamContext *context = [self findStreamContextFromPeripheral:peripheral andPSM:[psm unsignedShortValue]];
+        [context setConnectionStateCallbackId:[command.callbackId copy]];
+        [peripheral openL2CAPChannel:psm.unsignedShortValue];
+    }
+}
+
+- (void)receiveDataL2Cap:(CDVInvokedUrlCommand*)command {
+    NSLog(@"receiveDataL2Cap");
+
+    NSString *uuid = [command argumentAtIndex:0];
+    NSNumber *psm = [command argumentAtIndex:1];
+    CBPeripheral *peripheral = [self findPeripheralByUUID:uuid];
+
+    if (!peripheral) {
+        NSString *message = [NSString stringWithFormat:@"Peripheral %@ not found", uuid];
+        NSLog(@"%@", message);
+        CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:message];
+        [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+    } else {
+        BLEStreamContext *context = [self findStreamContextFromPeripheral:peripheral andPSM:[psm unsignedShortValue]];
+        [context setReadCallbackId:[command.callbackId copy]];
+    }
+}
+
+- (void)writeL2Cap:(CDVInvokedUrlCommand *)command {
+    NSLog(@"writeL2Cap");
+
+    NSString *uuid = [command argumentAtIndex:0];
+    NSNumber *psm = [command argumentAtIndex:1];
+    NSData *message = [command argumentAtIndex:2]; // This is binary
+    CBPeripheral *peripheral = [self findPeripheralByUUID:uuid];
+
+    if (!peripheral) {
+        NSString *message = [NSString stringWithFormat:@"Peripheral %@ not found", uuid];
+        NSLog(@"%@", message);
+        CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:message];
+        [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+    } else {
+        BLEStreamContext *context = [self findStreamContextFromPeripheral:peripheral andPSM:[psm unsignedShortValue]];
+        [context write:message callbackId:[command.callbackId copy]];
+    }
+}
 
 #pragma mark - timers
 
@@ -850,6 +928,24 @@
     }
 }
 
+- (void)peripheral:(CBPeripheral *)peripheral didOpenL2CAPChannel:(CBL2CAPChannel*)channel error:(NSError*)error {
+    NSLog(@"didOpenL2CAPChannel %@", channel);
+    BLEStreamContext *context = [self findStreamContextFromPeripheral:peripheral andPSM:[channel PSM]];
+    if (error) {
+        [context closeWithReason:[error localizedDescription]];
+    } else if (channel) {
+        [channel.inputStream setDelegate:context];
+        [channel.outputStream setDelegate:context];
+        [channel.inputStream scheduleInRunLoop:[NSRunLoop currentRunLoop] forMode:NSDefaultRunLoopMode];
+        [channel.outputStream scheduleInRunLoop:[NSRunLoop currentRunLoop] forMode:NSDefaultRunLoopMode];
+        [channel.inputStream open];
+        [channel.outputStream open];
+        [context setChannel:channel];
+    } else {
+        [context closeWithReason:@"No L2CAP channel provided"];
+    }
+}
+
 #pragma mark - internal implemetation
 
 - (CBPeripheral*)findPeripheralByUUID:(NSString*)uuid {
@@ -913,6 +1009,17 @@
         }
     }
    return nil; //Characteristic not found on this service
+}
+
+-(BLEStreamContext*) findStreamContextFromPeripheral:(CBPeripheral*)peripheral andPSM:(UInt16)psm {
+    NSString *key = [self keyForPeripheral:peripheral andPSM:psm];
+    BLEStreamContext *context = [l2CapContexts objectForKey:key];
+    if (!context) {
+        context = [BLEStreamContext alloc];
+        [context setCommandDelegate:self.commandDelegate];
+        [l2CapContexts setObject:context forKey:key];
+    }
+    return context;
 }
 
 // RedBearLab
@@ -1013,6 +1120,11 @@
     return [NSString stringWithFormat:@"%@|%@|%@", [peripheral uuidAsString], [characteristic.service UUID], [characteristic UUID]];
 }
 
+-(NSString *) keyForPeripheral: (CBPeripheral *)peripheral andPSM:(UInt16)psm {
+    return [NSString stringWithFormat:@"%@|%hu", [peripheral uuidAsString], psm];
+}
+
+
 +(BOOL) isKey: (NSString *)key forPeripheral:(CBPeripheral *)peripheral {
     NSArray *keyArray = [key componentsSeparatedByString: @"|"];
     return [[peripheral uuidAsString] compare:keyArray[0]] == NSOrderedSame;
@@ -1057,6 +1169,14 @@
             [self.commandDelegate sendPluginResult:result callbackId:callbackId];
             [notificationCallbacks removeObjectForKey:key];
             NSLog(@"Cleared notification callback %@ for key %@", callbackId, key);
+        }
+    }
+    for(id key in l2CapContexts.allKeys) {
+        if([BLECentralPlugin isKey:key forPeripheral:peripheral]) {
+            BLEStreamContext *context = [l2CapContexts valueForKey:key];
+            [context closeWithResult:result];
+            [l2CapContexts removeObjectForKey:key];
+            NSLog(@"Cleared L2CAP context for key %@", key);
         }
     }
 }

--- a/src/ios/BLEStreamContext.h
+++ b/src/ios/BLEStreamContext.h
@@ -1,0 +1,29 @@
+//
+//  BLEStreamContext
+//  Peripheral & PSM specific stream delegate
+//
+
+#import <Cordova/CDV.h>
+#import <Foundation/Foundation.h>
+#import <CoreBluetooth/CoreBluetooth.h>
+
+@class BLEStreamContext;
+
+@interface BLEStreamContext : NSObject <NSStreamDelegate> {
+    NSString *writeCallbackId;
+    NSData *sendQueue;
+    NSInteger sentBytes;
+};
+
+@property (nonatomic) NSString *connectionStateCallbackId;
+@property (nonatomic) NSString *readCallbackId;
+@property (nonatomic, weak) id <CDVCommandDelegate> commandDelegate;
+@property (nonatomic) CBL2CAPChannel *channel;
+
+-(void)closeWithReason:(NSString*)reason;
+-(void)closeWithResult:(CDVPluginResult*)result;
+
+-(void)write:(NSData*)message callbackId:(NSString*)callbackId;
+
+@end
+

--- a/src/ios/BLEStreamContext.m
+++ b/src/ios/BLEStreamContext.m
@@ -1,0 +1,125 @@
+//
+//  BLEStreamContext.m
+//  Peripheral & PSM specific stream delegate
+//
+
+#import "BLEStreamContext.h"
+
+@implementation BLEStreamContext
+
+- (void)stream:(NSStream *)stream handleEvent:(NSStreamEvent)eventCode {
+    switch (eventCode) {
+        case NSStreamEventOpenCompleted:
+            NSLog(@"L2CAP stream is opened");
+            if (self.connectionStateCallbackId) {
+                CDVPluginResult *result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
+                [result setKeepCallbackAsBool:true];
+                [self.commandDelegate sendPluginResult:result callbackId:self.connectionStateCallbackId];
+                // keep connection state callback as this will be triggered when the stream disconnects
+            }
+            break;
+            
+        case NSStreamEventEndEncountered:
+            NSLog(@"L2CAP stream end encountered");
+            [self closeWithReason:@"L2CAP Stream end encountered"];
+            break;
+            
+        case NSStreamEventHasBytesAvailable: {
+            // NSLog(@"L2CAP stream bytes available");
+            uint8_t buf[512];
+            NSInteger len = [(NSInputStream *)stream read:buf maxLength:512];
+            if (len > 0 && self.readCallbackId) {
+                NSData *data = [NSData dataWithBytes:buf length:len];
+                CDVPluginResult *result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsArrayBuffer:data];
+                [result setKeepCallbackAsBool:true];
+                [self.commandDelegate sendPluginResult:result callbackId:self.readCallbackId];
+            }
+            NSLog(@"Read %ld bytes from L2CAP stream", len);
+            break;
+        }
+            
+        case NSStreamEventHasSpaceAvailable:
+            // NSLog(@"L2CAP stream space is available");
+            [self doSend];
+            break;
+            
+        case NSStreamEventErrorOccurred:
+            NSLog(@"L2CAP stream error");
+            [self closeWithReason:@"L2CAP stream error"];
+            break;
+            
+        default:
+            NSLog(@"Unknown stream event: %lu", (unsigned long)eventCode);
+            break;
+    }
+}
+
+-(void)closeWithReason:(NSString*)reason {
+    CDVPluginResult *result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:reason];
+    [self closeWithResult:result];
+}
+
+-(void)closeWithResult:(CDVPluginResult*)result {
+    if (self.connectionStateCallbackId) {
+        [self.commandDelegate sendPluginResult:result callbackId:self.connectionStateCallbackId];
+        self.connectionStateCallbackId = nil;
+    }
+    
+    if (self.readCallbackId) {
+        [self.commandDelegate sendPluginResult:result callbackId:self.readCallbackId];
+        self.readCallbackId = nil;
+    }
+    
+    if (writeCallbackId) {
+        [self.commandDelegate sendPluginResult:result callbackId:writeCallbackId];
+        writeCallbackId = nil;
+    }
+    
+    sendQueue = nil;
+    
+    [self.channel.inputStream close];
+    [self.channel.inputStream removeFromRunLoop:[NSRunLoop currentRunLoop] forMode:NSDefaultRunLoopMode];
+    [self.channel.outputStream close];
+    [self.channel.outputStream removeFromRunLoop:[NSRunLoop currentRunLoop] forMode:NSDefaultRunLoopMode];
+    self.channel = nil;
+}
+
+-(void)write:(NSData*)message callbackId:(NSString*)callbackId {
+    CDVPluginResult *errorResult = nil;
+    if (sendQueue != nil) {
+        NSLog(@"Unable to write as L2CAP write already in progress");
+        errorResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR
+                                        messageAsString:@"L2CAP write already in progress"];
+    }
+    if (self.channel == nil) {
+        NSLog(@"Unable to write as L2CAP channel is closed");
+        errorResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR
+                                        messageAsString:@"L2CAP channel not connected"];
+    }
+    if (errorResult) {
+        [_commandDelegate sendPluginResult:errorResult callbackId:callbackId];
+        return;
+    }
+    sendQueue = message;
+    writeCallbackId = callbackId;
+    sentBytes = 0;
+    [self doSend];
+}
+
+-(void)doSend {
+    if (sendQueue && sentBytes < [sendQueue length]) {
+        sendQueue = [sendQueue subdataWithRange:NSMakeRange(sentBytes, [sendQueue length] - sentBytes)];
+        sentBytes = [self.channel.outputStream write:[sendQueue bytes] maxLength:[sendQueue length]];
+        NSLog(@"Sending %ld bytes to L2CAP stream", sentBytes);
+    } else {
+        sendQueue = nil;
+        if (writeCallbackId) {
+            NSLog(@"Sending bytes to L2CAP stream complete");
+            CDVPluginResult *result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
+            [_commandDelegate sendPluginResult:result callbackId:writeCallbackId];
+            writeCallbackId = nil;
+        }
+    }
+}
+
+@end

--- a/types.d.ts
+++ b/types.d.ts
@@ -31,6 +31,42 @@ declare namespace BLECentralPlugin {
         reportDuplicates?: boolean | undefined;
     }
 
+    interface L2CAPOptions {
+        psm: number;
+        secureChannel?: boolean;
+    }
+
+    interface L2CAP {
+        close(device_id: string, psm: number, success?: () => any, failure?: (error: string | BLEError) => any);
+
+        open(
+            device_id: string,
+            psmOrOptions: number | L2CAPOptions,
+            connectCallback?: () => any,
+            disconnectCallback?: (error: string | BLEError) => any
+        );
+
+        receiveData(device_id: string, psm: number, data: (data: ArrayBuffer) => any);
+
+        write(
+            device_id: string,
+            psm: number,
+            data: ArrayBuffer,
+            success?: () => {},
+            failure?: (error: string | BLEError) => any
+        );
+    }
+
+    interface L2CAPPromises {
+        open(
+            device_id: string,
+            psmOrOptions: number | L2CAPOptions,
+            disconnectCallback?: (error: string | BLEError) => any
+        ): Promise<void>;
+        close(device_id: string, psm: number): Promise<void>;
+        write(device_id: string, psm: number, data: ArrayBuffer): Promise<void>;
+    }
+
     interface RestoredState {
         peripherals?: PeripheralDataExtended[];
         scanServiceUUIDs?: string[];
@@ -77,6 +113,8 @@ declare namespace BLECentralPlugin {
     }
 
     export interface BLECentralPluginPromises extends BLECentralPluginCommon {
+        l2cap: L2CAPPromises;
+
         stopScan(): Promise<void>;
         disconnect(device_id: string): Promise<void>;
         read(device_id: string, service_uuid: string, characteristic_uuid: string): Promise<ArrayBuffer>;
@@ -104,6 +142,8 @@ declare namespace BLECentralPlugin {
     }
 
     export interface BLECentralPluginStatic extends BLECentralPluginCommon {
+        l2cap: L2CAP;
+
         /* sets the pin when device requires it.
            [iOS] setPin is not supported on iOS. */
         setPin(pin: string, success?: () => any, failure?: (error: string | BLEError) => any): void;

--- a/www/ble.js
+++ b/www/ble.js
@@ -396,15 +396,10 @@ module.exports.withPromises.l2cap = {
 
     open(device_id, psm, disconnectCallback) {
         return new Promise(function(resolve, reject) {
-          var rejected = false;
-            module.exports.l2cap.open(device_id, psm, resolve, function(e) {
-              if (!rejected) {
-                rejected = true;
-                reject(e);
-              } else {
-                disconnectCallback(e);
-              }
-            });
+          module.exports.l2cap.open(device_id, psm, resolve, function(e) {
+            disconnectCallback(e);
+            reject(e);
+          });
         });
     },
 

--- a/www/ble.js
+++ b/www/ble.js
@@ -368,3 +368,49 @@ module.exports.withPromises = {
         });
     },
 };
+
+module.exports.l2cap = {
+  close(device_id, psm, success, failure) {
+      cordova.exec(success, failure, 'BLE', 'closeL2Cap', [device_id, psm]);
+  },
+
+  open(device_id, psm, connectCallback, disconnectCallback) {
+      cordova.exec(connectCallback, disconnectCallback, 'BLE', 'openL2Cap', [device_id, psm]);
+  },
+
+  receiveData(device_id, psm, receive) {
+    cordova.exec(receive, function(){}, 'BLE', 'receiveDataL2Cap', [device_id, psm]);
+  },
+
+  write(device_id, psm, data, success, failure) {
+      cordova.exec(success, failure, 'BLE', 'writeL2Cap', [device_id, psm, data]);
+  },
+};
+
+module.exports.withPromises.l2cap = {
+    close(device_id, psm) {
+        return new Promise(function(resolve, reject) {
+            module.exports.l2cap.close(device_id, psm, resolve, reject);
+        });
+    },
+
+    open(device_id, psm, disconnectCallback) {
+        return new Promise(function(resolve, reject) {
+          var rejected = false;
+            module.exports.l2cap.open(device_id, psm, resolve, function(e) {
+              if (!rejected) {
+                rejected = true;
+                reject(e);
+              } else {
+                disconnectCallback(e);
+              }
+            });
+        });
+    },
+
+    write(device_id, psm, data) {
+        return new Promise(function(resolve, reject) {
+            module.exports.l2cap.write(device_id, psm, data, resolve, reject);
+        });
+    },
+};

--- a/www/ble.js
+++ b/www/ble.js
@@ -381,7 +381,7 @@ module.exports.l2cap = {
         psm = psmOrOptions.psm;
         settings = psmOrOptions;
       }
-      cordova.exec(connectCallback, disconnectCallback, 'BLE', 'openL2Cap', [device_id, psm, JSON.stringify(settings)]);
+      cordova.exec(connectCallback, disconnectCallback, 'BLE', 'openL2Cap', [device_id, psm, settings]);
   },
 
   receiveData(device_id, psm, receive) {

--- a/www/ble.js
+++ b/www/ble.js
@@ -374,8 +374,14 @@ module.exports.l2cap = {
       cordova.exec(success, failure, 'BLE', 'closeL2Cap', [device_id, psm]);
   },
 
-  open(device_id, psm, connectCallback, disconnectCallback) {
-      cordova.exec(connectCallback, disconnectCallback, 'BLE', 'openL2Cap', [device_id, psm]);
+  open(device_id, psmOrOptions, connectCallback, disconnectCallback) {
+      var psm = psmOrOptions;
+      var settings = {};
+      if (psmOrOptions != undefined && "psm" in psmOrOptions) {
+        psm = psmOrOptions.psm;
+        settings = psmOrOptions;
+      }
+      cordova.exec(connectCallback, disconnectCallback, 'BLE', 'openL2Cap', [device_id, psm, JSON.stringify(settings)]);
   },
 
   receiveData(device_id, psm, receive) {
@@ -394,9 +400,9 @@ module.exports.withPromises.l2cap = {
         });
     },
 
-    open(device_id, psm, disconnectCallback) {
+    open(device_id, psmOrOptions, disconnectCallback) {
         return new Promise(function(resolve, reject) {
-          module.exports.l2cap.open(device_id, psm, resolve, function(e) {
+          module.exports.l2cap.open(device_id, psmOrOptions, resolve, function(e) {
             disconnectCallback(e);
             reject(e);
           });


### PR DESCRIPTION
Hello @don 

This was something I recently found need of, and thought perhaps it might be of some interest to you. L2CAP (in case you weren't aware already) is basically a duplex stream "connection oriented channel" available in parallel to the normal GAP/GATT layers. This support is needed in order to fully implement support for the Bluetooth Object Transfer Service, for example. I have projects using this to stream large-ish binary files for example.

L2CAP is supported on iOS 11+, and since late last year, Android 10+ supports this now as well (not in this PR, but is on my todo list for the future PR if you like this one).

Any and all feedback welcome. I've given the interface my best shot, but if you have preferences about it's structure or approach, I'm happy to adjust it to suit. It goes without saying, this is freely given, and I completely understand if you don't want this feature as part of your plugin here.

Thanks for all your work maintaining this over the years... it's a very useful part of my problem-solving arsenal!