### PR TITLE
Run connect and disconnect in UI thread

### DIFF
--- a/src/android/BLECentralPlugin.java
+++ b/src/android/BLECentralPlugin.java
@@ -173,7 +173,11 @@ public class BLECentralPlugin extends CordovaPlugin implements BluetoothAdapter.
         } else if (action.equals(CONNECT)) {
 
             String macAddress = args.getString(0);
-            connect(callbackContext, macAddress);
+            cordova.getActivity().runOnUiThread(new Runnable() {
+                public void run() {
+                    connect(callbackContext, macAddress);
+                }
+            });
 
         } else if (action.equals(AUTOCONNECT)) {
 
@@ -183,7 +187,11 @@ public class BLECentralPlugin extends CordovaPlugin implements BluetoothAdapter.
         } else if (action.equals(DISCONNECT)) {
 
             String macAddress = args.getString(0);
-            disconnect(callbackContext, macAddress);
+            cordova.getActivity().runOnUiThread(new Runnable() {
+                public void run() {
+                    disconnect(callbackContext, macAddress);
+                }
+            });
 
         } else if (action.equals(QUEUE_CLEANUP)) {
 


### PR DESCRIPTION
According to https://github.com/NordicSemiconductor/Android-BLE-Library/issues/159 and https://github.com/NordicSemiconductor/Android-BLE-Library/issues/133, connect functions must be called from the UI thread on certain devices, specially Huawei phones.

