### PR TITLE
startScanWithOptions(): Add scanning options for Android BLEScanner.

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,19 @@ See the [location permission notes](#location-permission-notes) above for inform
 
 - __services__: List of services to discover, or [] to find all devices
 - __options__: an object specifying a set of name-value pairs. The currently acceptable options are:
-- _reportDuplicates_: true if duplicate devices should be reported, false (default) if devices should only be reported once. [optional]
+    * _reportDuplicates_: _true_ if duplicate devices should be reported, _false_ (default) if devices should only be reported once. [optional]
+    * _scanMode_: String defines [setScanMode()](https://developer.android.com/reference/kotlin/android/bluetooth/le/ScanSettings.Builder#setscanmode) argument on Android.  
+ Can be one of: _lowPower_ | _balanced_ | _lowLatency_ | _opportunistic_
+    * _callbackType_: String defines [setCallbackType()](https://developer.android.com/reference/kotlin/android/bluetooth/le/ScanSettings.Builder#setcallbacktype) argument on Android.  
+ Can be one of: _all_ | _first_ | _lost_
+    * _matchMode_: String defines [setMatchMode()](https://developer.android.com/reference/kotlin/android/bluetooth/le/ScanSettings.Builder#setmatchmode) argument on Android.  
+ Can be one of: _aggressive_ | _sticky_
+    * _numOfMatches_: String defines [setNumOfMatches()](https://developer.android.com/reference/kotlin/android/bluetooth/le/ScanSettings.Builder#setnumofmatches) argument on Android.  
+ Can be one of: _one_ | _few_ | _max_
+    * _phy_: String for [setPhy()](https://developer.android.com/reference/kotlin/android/bluetooth/le/ScanSettings.Builder#setphy) on Android.  
+ Can be one of: _1m_ | _coded_ | _all_
+    * _legacy_: _true_ or _false_ to [control filtering](https://developer.android.com/reference/kotlin/android/bluetooth/le/ScanSettings.Builder#setlegacy) bluetooth spec.pre-4.2 advertisements on Android.  
+    * _reportDelay_: Milliseconds for [setReportDelay()](https://developer.android.com/reference/kotlin/android/bluetooth/le/ScanSettings.Builder#setreportdelay) on Android. _0_ to be notified of results immediately. Values > _0_ causes the scan results to be queued up and delivered after the requested delay or when the internal buffers fill up.
 - __success__: Success callback function that is invoked which each discovered device.
 - __failure__: Error callback function, invoked when error occurs. [optional]
 

--- a/src/android/BLECentralPlugin.java
+++ b/src/android/BLECentralPlugin.java
@@ -331,7 +331,109 @@ public class BLECentralPlugin extends CordovaPlugin {
 
             resetScanOptions();
             this.reportDuplicates = options.optBoolean("reportDuplicates", false);
-            findLowEnergyDevices(callbackContext, serviceUUIDs, -1);
+            ScanSettings.Builder scanSettings = new ScanSettings.Builder();
+
+            switch (options.optString("scanMode", "")) {
+                case "":
+                    break;
+                case "lowPower":
+                    scanSettings.setScanMode( ScanSettings.SCAN_MODE_LOW_POWER );
+                    break;
+                case "balanced":
+                    scanSettings.setScanMode( ScanSettings.SCAN_MODE_BALANCED );
+                    break;
+                case "lowLatency":
+                    scanSettings.setScanMode( ScanSettings.SCAN_MODE_LOW_LATENCY );
+                    break;
+                case "opportunistic":
+                    scanSettings.setScanMode( ScanSettings.SCAN_MODE_OPPORTUNISTIC );
+                    break;
+                default:
+                    callbackContext.error("scanMode must be one of: lowPower | balanced | lowLatency");
+                    validAction = false;
+                    break;
+            }
+
+            switch (options.optString("callbackType", "")) {
+                case "":
+                    break;
+                case "all":
+                    scanSettings.setCallbackType( ScanSettings.CALLBACK_TYPE_ALL_MATCHES );
+                    break;
+                case "first":
+                    scanSettings.setCallbackType( ScanSettings.CALLBACK_TYPE_FIRST_MATCH );
+                    break;
+                case "lost":
+                    scanSettings.setCallbackType( ScanSettings.CALLBACK_TYPE_MATCH_LOST );
+                    break;
+                default:
+                    callbackContext.error("callbackType must be one of: all | first | lost");
+                    validAction = false;
+                    break;
+            }
+
+            switch (options.optString("matchMode", "")) {
+                case "":
+                    break;
+                case "aggressive":
+                    scanSettings.setCallbackType( ScanSettings.MATCH_MODE_AGGRESSIVE );
+                    break;
+                case "sticky":
+                    scanSettings.setCallbackType( ScanSettings.MATCH_MODE_STICKY );
+                    break;
+                default:
+                    callbackContext.error("matchMode must be one of: aggressive | sticky");
+                    validAction = false;
+                    break;
+            }
+
+            switch (options.optString("numOfMatches", "")) {
+                case "":
+                    break;
+                case "one":
+                    scanSettings.setNumOfMatches( ScanSettings.MATCH_NUM_ONE_ADVERTISEMENT );
+                    break;
+                case "few":
+                    scanSettings.setNumOfMatches( ScanSettings.MATCH_NUM_FEW_ADVERTISEMENT );
+                    break;
+                case "max":
+                    scanSettings.setNumOfMatches( ScanSettings.MATCH_NUM_MAX_ADVERTISEMENT );
+                    break;
+                default:
+                    callbackContext.error("numOfMatches must be one of: one | few | max");
+                    validAction = false;
+                    break;
+            }
+
+            switch (options.optString("phy", "")) {
+                case "":
+                    break;
+                case "1m":
+                    scanSettings.setPhy( BluetoothDevice.PHY_LE_1M );
+                    break;
+                case "coded":
+                    scanSettings.setPhy( BluetoothDevice.PHY_LE_CODED );
+                    break;
+                case "all":
+                    scanSettings.setPhy( ScanSettings.PHY_LE_ALL_SUPPORTED );
+                    break;
+                default:
+                    callbackContext.error("phy must be one of: 1m | coded | all");
+                    validAction = false;
+                    break;
+            }
+
+            if (validAction) {
+                String LEGACY = "legacy";
+                if (!options.isNull(LEGACY))
+                    scanSettings.setLegacy( options.getBoolean(LEGACY) );
+
+                long reportDelay = options.optLong("reportDelay", -1 );
+                if (reportDelay >= 0L)
+                    scanSettings.setReportDelay( reportDelay );
+
+                findLowEnergyDevices(callbackContext, serviceUUIDs, -1, scanSettings.build() );
+            }
 
         } else if (action.equals(BONDED_DEVICES)) {
 
@@ -704,8 +806,11 @@ public class BLECentralPlugin extends CordovaPlugin {
         }
     };
 
-    private void findLowEnergyDevices(CallbackContext callbackContext, UUID[] serviceUUIDs, int scanSeconds) {
 
+    private void findLowEnergyDevices(CallbackContext callbackContext, UUID[] serviceUUIDs, int scanSeconds) {
+        findLowEnergyDevices( callbackContext, serviceUUIDs, scanSeconds, new ScanSettings.Builder().build() );
+    }
+    private void findLowEnergyDevices(CallbackContext callbackContext, UUID[] serviceUUIDs, int scanSeconds, ScanSettings scanSettings) {
 
 
         if (!locationServicesEnabled()) {
@@ -760,18 +865,15 @@ public class BLECentralPlugin extends CordovaPlugin {
 
         discoverCallback = callbackContext;
         bluetoothLeScanner = bluetoothAdapter.getBluetoothLeScanner();
+        List<ScanFilter> filters = new ArrayList<ScanFilter>();
         if (serviceUUIDs != null && serviceUUIDs.length > 0) {
-            List<ScanFilter> filters = new ArrayList<ScanFilter>();
             for (UUID uuid : serviceUUIDs) {
                 ScanFilter filter = new ScanFilter.Builder().setServiceUuid(
                         new ParcelUuid(uuid)).build();
                 filters.add(filter);
             }
-            ScanSettings settings = new ScanSettings.Builder().build();
-            bluetoothLeScanner.startScan(filters, settings, leScanCallback);
-        } else {
-            bluetoothLeScanner.startScan(leScanCallback);
         }
+        bluetoothLeScanner.startScan(filters, scanSettings, leScanCallback);
 
         if (scanSeconds > 0) {
             Handler handler = new Handler();


### PR DESCRIPTION
Add Android-only options for `scanMode`, `callbackType`, `matchMode`, `numOfMatches`, `phy`, `legacy`, `reportDelay` for fine-tune of scanning on Android.

Add info into README.