### PR TITLE
Fix for #821 (Removed ACCESS_BACKGROUND_LOCATION)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Bluetooth Low Energy (BLE) Central Plugin for Apache Cordova
 
+## Forked to fix ACCESS_BACKGROUND_LOCATION for Android
+
 This plugin enables communication between a phone and Bluetooth Low Energy (BLE) peripherals.
 
 The plugin provides a simple [JavaScript API](#api) for iOS and Android.

--- a/plugin.xml
+++ b/plugin.xml
@@ -58,7 +58,6 @@
         <config-file target="AndroidManifest.xml" parent="/manifest">
             <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
             <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
-            <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION"/>
             <uses-permission android:name="android.permission.BLUETOOTH"/>
             <uses-permission android:name="android.permission.BLUETOOTH_ADMIN"/>
         </config-file>

--- a/src/android/BLECentralPlugin.java
+++ b/src/android/BLECentralPlugin.java
@@ -719,8 +719,7 @@ public class BLECentralPlugin extends CordovaPlugin {
                 this.scanSeconds = scanSeconds;
 
                 String[] permissions = {
-                        Manifest.permission.ACCESS_FINE_LOCATION,
-                        "android.permission.ACCESS_BACKGROUND_LOCATION"     // (API 29) Manifest.permission.ACCESS_BACKGROUND_LOCATION
+                        Manifest.permission.ACCESS_FINE_LOCATION
                 };
 
                 PermissionHelper.requestPermissions(this, REQUEST_ACCESS_LOCATION, permissions);


### PR DESCRIPTION
Removed ACCESS_BACKGROUND_LOCATION in android to match Google Play Policy. 

 