### PR TITLE
Make ACCESS_BACKGROUND_LOCATION permission optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,12 @@ It is possible to delay the initialization of the plugin on iOS. Normally the Bl
 
     --variable IOS_INIT_ON_LOAD=false
 
+### Android
+
+If your app targets Android 10 (API level 29) or higher, you have also the option of requesting the ACCESS_BACKGROUND_LOCATION permission. If your app has a feature that requires it, set `ACCESS_BACKGROUND_LOCATION ` to true when installing.
+
+    --variable ACCESS_BACKGROUND_LOCATION=true
+
 # API
 
 ## Methods

--- a/hooks/after_prepare.js
+++ b/hooks/after_prepare.js
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+'use strict';
+
+var fs = require('fs');
+
+var ACCESS_BACKGROUND_LOCATION_PERMISSION = '<uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />';
+
+module.exports = function (context) {
+    const accessBackgroundLocationVariable = getAccessBackgroundLocationVariable();
+    const manifestPath = getAndroidManifestFilePath(context);
+    const androidManifest = fs.readFileSync(manifestPath).toString();
+    if (accessBackgroundLocationVariable === 'true') {
+        if (!accessBackgroundLocationExists(androidManifest)) {
+            addAccessBackgroundLocationToManifest(manifestPath, androidManifest);
+            console.log(context.opts.plugin.id + ': ACCESS_BACKGROUND_LOCATION permission added to ' + manifestPath);
+        } else {
+            console.log(context.opts.plugin.id + ': ACCESS_BACKGROUND_LOCATION permission already exists in ' + manifestPath);
+        }
+    } else {
+        if (accessBackgroundLocationExists(androidManifest)) {
+            removeAccessBackgroundLocationToManifest(manifestPath, androidManifest);
+            console.log(context.opts.plugin.id + ': ACCESS_BACKGROUND_LOCATION permission removed from ' + manifestPath);
+        } else {
+            console.log(context.opts.plugin.id + ': ACCESS_BACKGROUND_LOCATION permission does not exists in ' + manifestPath);
+        }
+    }
+}
+
+var getAccessBackgroundLocationVariable = function () {
+    if (process.argv.join("|").indexOf("ACCESS_BACKGROUND_LOCATION=") > -1) {
+        return process.argv.join("|").match(/ACCESS_BACKGROUND_LOCATION=(.*?)(\||$)/)[1];
+    } else {
+        return getPreferenceValue("ACCESS_BACKGROUND_LOCATION");
+    }
+}
+
+var getPreferenceValue = function (name) {
+    const config = fs.readFileSync('config.xml').toString();
+    var preferenceValue = getPreferenceValueFromConfig(config, name);
+    if (!preferenceValue) {
+        const packageJson = fs.readFileSync('package.json').toString();
+        preferenceValue = getPreferenceValueFromPackageJson(packageJson, name);
+    }
+    return preferenceValue;
+}
+
+var getPreferenceValueFromConfig = function (config, name) {
+    const value = config.match(new RegExp('name="' + name + '" value="(.*?)"', "i"));
+    if (value && value[1]) {
+        return value[1];
+    } else {
+        return null;
+    }
+}
+
+var getPreferenceValueFromPackageJson = function (packageJson, name) {
+    const value = packageJson.match(new RegExp('"' + name + '":\\s"(.*?)"', "i"));
+    if (value && value[1]) {
+        return value[1];
+    } else {
+        return null;
+    }
+}
+
+var getAndroidManifestFilePath = function (context) {
+    const manifestPath = {
+        cordovaAndroid6: context.opts.projectRoot + '/platforms/android/AndroidManifest.xml',
+        cordovaAndroid7: context.opts.projectRoot + '/platforms/android/app/src/main/AndroidManifest.xml'
+    };
+    if (fs.existsSync(manifestPath.cordovaAndroid7)) {
+        return manifestPath.cordovaAndroid7;
+    } else if (fs.existsSync(manifestPath.cordovaAndroid6)) {
+        return manifestPath.cordovaAndroid6;
+    } else {
+        throw "Can't find AndroidManifest.xml in platforms/Android";
+    }
+}
+
+var accessBackgroundLocationExists = function (manifest) {
+    const value = manifest.search(ACCESS_BACKGROUND_LOCATION_PERMISSION);
+    if (value === -1) {
+        return false;
+    } else {
+        return true;
+    }
+}
+
+var addAccessBackgroundLocationToManifest = function (manifestPath, androidManifest) {
+    const index = androidManifest.search('</manifest>');
+    const accessBackgroundLocationPermissionLine = '    ' + ACCESS_BACKGROUND_LOCATION_PERMISSION + '\n';
+    const updatedManifest = androidManifest.substring(0, index) + accessBackgroundLocationPermissionLine + androidManifest.substring(index);
+    fs.writeFileSync(manifestPath, updatedManifest);
+}
+
+var removeAccessBackgroundLocationToManifest = function (manifestPath, androidManifest) {
+    const accessBackgroundLocationPermissionLine = '    ' + ACCESS_BACKGROUND_LOCATION_PERMISSION + '\n';
+    const updatedManifest = androidManifest.replace(accessBackgroundLocationPermissionLine, '');
+    fs.writeFileSync(manifestPath, updatedManifest);
+}

--- a/plugin.xml
+++ b/plugin.xml
@@ -49,6 +49,9 @@
     </platform>
 
     <platform name="android">
+        
+        <preference name="ACCESS_BACKGROUND_LOCATION" default="false" />
+        
         <config-file target="res/xml/config.xml" parent="/widget">
             <feature name="BLE">
                 <param name="android-package" value="com.megster.cordova.ble.central.BLECentralPlugin"/>
@@ -58,10 +61,15 @@
         <config-file target="AndroidManifest.xml" parent="/manifest">
             <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
             <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
-            <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION"/>
-            <uses-permission android:name="android.permission.BLUETOOTH"/>
-            <uses-permission android:name="android.permission.BLUETOOTH_ADMIN"/>
+            <uses-permission android:name="android.permission.BLUETOOTH" />
+            <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
         </config-file>
+
+        <config-file target="res/xml/config.xml" parent="/*">
+            <preference name="accessBackgroundLocation" value="$ACCESS_BACKGROUND_LOCATION"/>
+        </config-file>
+
+        <hook type="after_prepare" src="hooks/after_prepare.js"/>
 
         <source-file src="src/android/BLECentralPlugin.java"
             target-dir="src/com/megster/cordova/ble/central"/>

--- a/src/android/BLECentralPlugin.java
+++ b/src/android/BLECentralPlugin.java
@@ -718,12 +718,15 @@ public class BLECentralPlugin extends CordovaPlugin {
                 this.serviceUUIDs = serviceUUIDs;
                 this.scanSeconds = scanSeconds;
 
-                String[] permissions = {
-                        Manifest.permission.ACCESS_FINE_LOCATION,
-                        "android.permission.ACCESS_BACKGROUND_LOCATION"     // (API 29) Manifest.permission.ACCESS_BACKGROUND_LOCATION
-                };
-
-                PermissionHelper.requestPermissions(this, REQUEST_ACCESS_LOCATION, permissions);
+                List<String> permissionsList = new ArrayList<String>();
+                permissionsList.add(Manifest.permission.ACCESS_FINE_LOCATION);
+                String accessBackgroundLocation = this.preferences.getString("accessBackgroundLocation", "false");
+                if(accessBackgroundLocation == "true") {
+                    LOG.w(TAG, "ACCESS_BACKGROUND_LOCATION is being requested");
+                    permissionsList.add("android.permission.ACCESS_BACKGROUND_LOCATION"); // (API 29) Manifest.permission.ACCESS_BACKGROUND_LOCATION
+                }
+                String[] permissionsArray = new String[permissionsList.size()];
+                PermissionHelper.requestPermissions(this, REQUEST_ACCESS_LOCATION, permissionsList.toArray(permissionsArray));
                 return;
             }
         } else {


### PR DESCRIPTION
Hello @don,

I have created a pull request (as discussed in #821) where the ACCESS_BACKGROUND_LOCATION permission is optional.

You can enable it as shown below:

```
$ cordova plugin add cordova-plugin-ble-central --variable ACCESS_BACKGROUND_LOCATION=true
```

- I used a hook of type `after_prepare` to add the `ACCESS_BACKGROUND_LOCATION` on the `AndroidManifest.xml` file. 
- I also used the variable as a preference to use it in the Java file to request the `ACCESS_BACKGROUND_LOCATION` permission dynamically.
- I updated the README.md file with the information about this variable

I tested it and it is working as it should.