### PR TITLE
Ensure only a single processCommands loop can run at a time (Android)

### DIFF
--- a/src/android/Peripheral.java
+++ b/src/android/Peripheral.java
@@ -31,6 +31,7 @@ import java.util.*;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 import java.lang.reflect.Method;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Peripheral wraps the BluetoothDevice and provides methods to convert to JSON.
@@ -51,7 +52,7 @@ public class Peripheral extends BluetoothGattCallback {
     private boolean connected = false;
     private boolean connecting = false;
     private ConcurrentLinkedQueue<BLECommand> commandQueue = new ConcurrentLinkedQueue<BLECommand>();
-    private boolean bleProcessing;
+    private final AtomicBoolean bleProcessing = new AtomicBoolean();
 
     BluetoothGatt gatt;
 
@@ -802,10 +803,11 @@ public class Peripheral extends BluetoothGattCallback {
     }
 
     public void queueCleanup() {
-        bleProcessing = false;
+        bleProcessing.set(true); // Stop anything else trying to process
         for (BLECommand command = commandQueue.poll(); command != null; command = commandQueue.poll()) {
             command.getCallbackContext().error("Peripheral Disconnected");
         }
+        bleProcessing.set(false); // Now re-allow processing
     }
 
     private void callbackCleanup() {
@@ -832,55 +834,49 @@ public class Peripheral extends BluetoothGattCallback {
         result.setKeepCallback(true);
         command.getCallbackContext().sendPluginResult(result);
 
-        if (!bleProcessing) {
-            processCommands();
-        }
+        processCommands();
     }
 
     // command finished, queue the next command
     private void commandCompleted() {
         LOG.d(TAG,"Processing Complete");
-        bleProcessing = false;
+        bleProcessing.set(false);
         processCommands();
     }
 
     // process the queue
     private void processCommands() {
+        final boolean canProcess = bleProcessing.compareAndSet(false, true);
+        if (!canProcess) { return; }
         LOG.d(TAG,"Processing Commands");
-
-        if (bleProcessing) { return; }
 
         BLECommand command = commandQueue.poll();
         if (command != null) {
             if (command.getType() == BLECommand.READ) {
                 LOG.d(TAG,"Read %s", command.getCharacteristicUUID());
-                bleProcessing = true;
                 readCharacteristic(command.getCallbackContext(), command.getServiceUUID(), command.getCharacteristicUUID());
             } else if (command.getType() == BluetoothGattCharacteristic.WRITE_TYPE_DEFAULT) {
                 LOG.d(TAG,"Write %s", command.getCharacteristicUUID());
-                bleProcessing = true;
                 writeCharacteristic(command.getCallbackContext(), command.getServiceUUID(), command.getCharacteristicUUID(), command.getData(), command.getType());
             } else if (command.getType() == BluetoothGattCharacteristic.WRITE_TYPE_NO_RESPONSE) {
                 LOG.d(TAG,"Write No Response %s", command.getCharacteristicUUID());
-                bleProcessing = true;
                 writeCharacteristic(command.getCallbackContext(), command.getServiceUUID(), command.getCharacteristicUUID(), command.getData(), command.getType());
             } else if (command.getType() == BLECommand.REGISTER_NOTIFY) {
                 LOG.d(TAG,"Register Notify %s", command.getCharacteristicUUID());
-                bleProcessing = true;
                 registerNotifyCallback(command.getCallbackContext(), command.getServiceUUID(), command.getCharacteristicUUID());
             } else if (command.getType() == BLECommand.REMOVE_NOTIFY) {
                 LOG.d(TAG,"Remove Notify %s", command.getCharacteristicUUID());
-                bleProcessing = true;
                 removeNotifyCallback(command.getCallbackContext(), command.getServiceUUID(), command.getCharacteristicUUID());
             } else if (command.getType() == BLECommand.READ_RSSI) {
                 LOG.d(TAG,"Read RSSI");
-                bleProcessing = true;
                 readRSSI(command.getCallbackContext());
             } else {
                 // this shouldn't happen
+                bleProcessing.set(false);
                 throw new RuntimeException("Unexpected BLE Command type " + command.getType());
             }
         } else {
+            bleProcessing.set(false);
             LOG.d(TAG, "Command Queue is empty.");
         }
 


### PR DESCRIPTION
Saw a very rare edge case where if multiple reads arrived at the perfect moment they
could run two simultaneous reads at the same time, causing one of the reads
to get the very wrong callback.

In the logs, this looked something like (note two Read logs with no Processing Complete log to separate them):

```
D/BLEPlugin: action = read
D/Peripheral: Queuing Command com.megster.cordova.ble.central.BLECommand@3f5ebef
D/Peripheral: onCharacteristicRead android.bluetooth.BluetoothGattCharacteristic@77276fc
D/Peripheral: Processing Complete
D/Peripheral: Processing Commands
D/BLEPlugin: action = read
D/Peripheral: Queuing Command com.megster.cordova.ble.central.BLECommand@ee5a185
D/Peripheral: Processing Commands
D/Peripheral: Read 84a98001-24c5-4726-9860-0847bb1d01e7
D/Peripheral: Read 84a94001-24c5-4726-9860-0847bb1d01e7
D/Peripheral: Processing Complete
D/Peripheral: Processing Commands
D/Peripheral: Command Queue is empty.
```