### PR TITLE
Added aggressive scan option for Android

### DIFF
--- a/src/android/BLECentralPlugin.java
+++ b/src/android/BLECentralPlugin.java
@@ -790,7 +790,6 @@ public class BLECentralPlugin extends CordovaPlugin {
                         new ParcelUuid(uuid)).build();
                 filters.add(filter);
             }
-            ScanSettings settings = new ScanSettings.Builder().build();
             bluetoothLeScanner.startScan(filters, settings, leScanCallback);
         } else {
             bluetoothLeScanner.startScan(null, settings, leScanCallback);


### PR DESCRIPTION
Hi, I have added an option for aggressive scanning in the scanWithOptions function. As you may know, BLE has different scan modes like not very frequent, more frequent, and don't miss a thing which is in turn best option for not missing advertising packets but most battery consuming (actually not that much). I had two projects:
1. To detect radio LF strength reported by BLE device. I needed not to miss a message (advertising packet) as this was crucial.
2. To detect location according to BLE beacons (Eddystone and iBeacons) and again I had not to miss a packet.
Solution was to enable this aggressive mode, which has been tested thoughtfully and works like a charm. If you like it, you can add it to the main project.
Thanks, and wish you a great day!
Cheers,
Boris