### PR TITLE
Allow iOS state restoration as an opt-in feature #717

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ It is possible to delay the initialization of the plugin on iOS. Normally the Bl
 
     --variable IOS_INIT_ON_LOAD=false
 
+If background scanning and operation is required, the [iOS restore state](https://developer.apple.com/library/archive/documentation/NetworkingInternetWeb/Conceptual/CoreBluetooth_concepts/CoreBluetoothBackgroundProcessingForIOSApps/PerformingTasksWhileYourAppIsInTheBackground.html#//apple_ref/doc/uid/TP40013257-CH7-SW13) should be enabled:
+
+    --variable BLUETOOTH_RESTORE_STATE=true
+
 ### Android
 
 If your app targets Android 10 (API level 29) or higher, you have also the option of requesting the ACCESS_BACKGROUND_LOCATION permission. If your app has a feature that requires it, set `ACCESS_BACKGROUND_LOCATION ` to true when installing.
@@ -1032,6 +1036,14 @@ Add a new section to config.xml
     </platform>
 
 See [ble-background](https://github.com/don/ble-background) example project for more details.
+
+Additional, iOS state restoration should be enabled if long-running scans or connects should be restarted after the phone is rebooted or the app is suspended by iOS.See [iOS restore state](https://developer.apple.com/library/archive/documentation/NetworkingInternetWeb/Conceptual/CoreBluetooth_concepts/CoreBluetoothBackgroundProcessingForIOSApps/PerformingTasksWhileYourAppIsInTheBackground.html#//apple_ref/doc/uid/TP40013257-CH7-SW13) for the details and limitations of this feature.
+
+To activate iOS state restoration, set the BLUETOOTH_RESTORE_STATE to true when adding the plugin to the project:
+
+    --variable BLUETOOTH_RESTORE_STATE=true
+
+It's important to note that iOS will **not** automatically relaunch an application under some conditions. For a detailed list of these conditions, see the [iOS Technical QA on the subject](https://developer.apple.com/library/archive/qa/qa1962/_index.html).
 
 # Testing the Plugin
 

--- a/README.md
+++ b/README.md
@@ -1070,6 +1070,10 @@ To activate iOS state restoration, set the BLUETOOTH_RESTORE_STATE to true when 
 
     --variable BLUETOOTH_RESTORE_STATE=true
 
+By default, the app id (otherwise known as the bundle identifier) will be used as the iOS restore identifier key. This can be overridden by setting the variable to the desired key directly. For example:
+
+    --variable BLUETOOTH_RESTORE_STATE=my.custom.restoration.identifier.key
+
 It's important to note that iOS will **not** automatically relaunch an application under some conditions. For a detailed list of these conditions, see the [iOS Technical QA on the subject](https://developer.apple.com/library/archive/qa/qa1962/_index.html).
 
 # Testing the Plugin

--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ If background scanning and operation is required, the [iOS restore state](https:
 
     --variable BLUETOOTH_RESTORE_STATE=true
 
+For more information about background operation, see [Background Scanning and Notifications on iOS](#background-scanning-and-notifications-on-ios).
+
 ### Android
 
 If your app targets Android 10 (API level 29) or higher, you have also the option of requesting the ACCESS_BACKGROUND_LOCATION permission. If your app has a feature that requires it, set `ACCESS_BACKGROUND_LOCATION ` to true when installing.
@@ -100,6 +102,7 @@ If your app targets Android 10 (API level 29) or higher, you have also the optio
 - [ble.readRSSI](#readrssi)
 - [ble.connectedPeripheralsWithServices](#connectedperipheralswithservices)
 - [ble.peripheralsWithIdentifiers](#peripheralswithidentifiers)
+- [ble.restoredBluetoothState](#restoredbluetoothstate)
 - [ble.bondedDevices](#bondeddevices)
 
 ## scan
@@ -851,6 +854,30 @@ Sends a list of known peripherals by their identifiers to the success callback. 
 
  * iOS
 
+## restoredBluetoothState
+
+Retrieve the CBManager restoration state (if applicable)
+
+    ble.restoredBluetoothState(success, failure);
+    await ble.withPromises.restoredBluetoothState();
+
+### Description
+
+**Use of this feature requires the [BLUETOOTH_RESTORE_STATE variable to be set](#background-scanning-and-notifications-on-ios) to true.** For more information about background operation, see [Background Scanning and Notifications on iOS](#background-scanning-and-notifications-on-ios).
+
+Retrives the state dictionary that [iOS State Preservation and Restoration](https://developer.apple.com/library/archive/documentation/NetworkingInternetWeb/Conceptual/CoreBluetooth_concepts/CoreBluetoothBackgroundProcessingForIOSApps/PerformingTasksWhileYourAppIsInTheBackground.html#//apple_ref/doc/uid/TP40013257-CH7-SW10) will supply when the application was launched by iOS.
+
+If the application has no state restored, this will return an empty object.
+
+### Parameters
+
+-   __success__: Success callback function, invoked with the restored Bluetooth state (if any)
+-   __failure__: Error callback function
+
+### Supported Platforms
+
+*   iOS
+
 ## bondedDevices
 
 Find the bonded devices.
@@ -1037,7 +1064,7 @@ Add a new section to config.xml
 
 See [ble-background](https://github.com/don/ble-background) example project for more details.
 
-Additional, iOS state restoration should be enabled if long-running scans or connects should be restarted after the phone is rebooted or the app is suspended by iOS.See [iOS restore state](https://developer.apple.com/library/archive/documentation/NetworkingInternetWeb/Conceptual/CoreBluetooth_concepts/CoreBluetoothBackgroundProcessingForIOSApps/PerformingTasksWhileYourAppIsInTheBackground.html#//apple_ref/doc/uid/TP40013257-CH7-SW13) for the details and limitations of this feature.
+Additionally, iOS state restoration should be enabled if long-running scans or connects should be restarted after the phone is rebooted or the app is suspended by iOS. See [iOS restore state](https://developer.apple.com/library/archive/documentation/NetworkingInternetWeb/Conceptual/CoreBluetooth_concepts/CoreBluetoothBackgroundProcessingForIOSApps/PerformingTasksWhileYourAppIsInTheBackground.html#//apple_ref/doc/uid/TP40013257-CH7-SW13) for the details and limitations of this feature.
 
 To activate iOS state restoration, set the BLUETOOTH_RESTORE_STATE to true when adding the plugin to the project:
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -20,6 +20,7 @@
     <platform name="ios">
 
         <preference name="IOS_INIT_ON_LOAD" default="true" />
+        <preference name="BLUETOOTH_RESTORE_STATE" default="false" />
         <config-file target="config.xml" parent="/widget">
             <feature name="BLE">
                 <param name="ios-package" value="BLECentralPlugin" onload="$IOS_INIT_ON_LOAD"/>
@@ -45,6 +46,9 @@
         </config-file>
         <config-file target="*-Info.plist" parent="NSBluetoothAlwaysUsageDescription">
             <string>$BLUETOOTH_USAGE_DESCRIPTION</string>
+        </config-file>
+        <config-file target="config.xml" parent="/*">
+            <preference name="bluetooth_restore_state" value="$BLUETOOTH_RESTORE_STATE"/>
         </config-file>
     </platform>
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -20,7 +20,7 @@
     <platform name="ios">
 
         <preference name="IOS_INIT_ON_LOAD" default="true" />
-        <preference name="BLUETOOTH_RESTORE_STATE" default="false" />
+        <preference name="BLUETOOTH_RESTORE_STATE" default="" />
         <config-file target="config.xml" parent="/widget">
             <feature name="BLE">
                 <param name="ios-package" value="BLECentralPlugin" onload="$IOS_INIT_ON_LOAD"/>

--- a/src/ios/BLECentralPlugin.h
+++ b/src/ios/BLECentralPlugin.h
@@ -35,6 +35,7 @@
     NSMutableDictionary *stopNotificationCallbacks;
     NSMutableDictionary *connectCallbackLatches;
     NSMutableDictionary *readRSSICallbacks;
+    NSDictionary<NSString*,id> *restoredState;
 }
 
 @property (strong, nonatomic) NSMutableSet *peripherals;
@@ -67,6 +68,8 @@
 - (void)onReset;
 
 - (void)readRSSI:(CDVInvokedUrlCommand *)command;
+
+- (void)restoredBluetoothState:(CDVInvokedUrlCommand *)command;
 
 @end
 

--- a/src/ios/BLECentralPlugin.m
+++ b/src/ios/BLECentralPlugin.m
@@ -23,6 +23,7 @@
     NSDictionary *bluetoothStates;
 }
 - (CBPeripheral *)findPeripheralByUUID:(NSString *)uuid;
+- (CBPeripheral *)retrievePeripheralWithUUID:(NSString *)uuid;
 - (void)stopScanTimer:(NSTimer *)timer;
 @end
 
@@ -72,12 +73,14 @@
 - (void)centralManager:(CBCentralManager *)central willRestoreState:(NSDictionary<NSString *,id> *)state {
 }
 
-// TODO add timeout
 - (void)connect:(CDVInvokedUrlCommand *)command {
     NSLog(@"connect");
     NSString *uuid = [command argumentAtIndex:0];
 
     CBPeripheral *peripheral = [self findPeripheralByUUID:uuid];
+    if (!peripheral) {
+        peripheral = [self retrievePeripheralWithUUID:uuid];
+    }
 
     if (peripheral) {
         NSLog(@"Connecting to peripheral with UUID : %@", uuid);
@@ -101,6 +104,9 @@
     NSString *uuid = [command argumentAtIndex:0];
     
     CBPeripheral *peripheral = [self findPeripheralByUUID:uuid];
+    if (!peripheral) {
+        peripheral = [self retrievePeripheralWithUUID:uuid];
+    }
     
     if (peripheral) {
         NSLog(@"Autoconnecting to peripheral with UUID : %@", uuid);
@@ -728,6 +734,17 @@
             peripheral = p;
             break;
         }
+    }
+    return peripheral;
+}
+
+- (CBPeripheral*)retrievePeripheralWithUUID:(NSString*)uuid {
+    NSUUID *typedUUID = [[NSUUID alloc] initWithUUIDString:uuid];
+    NSArray *existingPeripherals = [manager retrievePeripheralsWithIdentifiers:@[typedUUID]];
+    CBPeripheral *peripheral = nil;
+    if ([existingPeripherals count] > 0) {
+        peripheral = [existingPeripherals firstObject];
+        [peripherals addObject:peripheral];
     }
     return peripheral;
 }

--- a/src/ios/BLECentralPlugin.m
+++ b/src/ios/BLECentralPlugin.m
@@ -43,8 +43,11 @@
 
     NSDictionary *pluginSettings = [[self commandDelegate] settings];
     NSString *enableState = pluginSettings[@"bluetooth_restore_state"];
-    if (enableState != nil && [@"true" isEqualToString:[enableState lowercaseString]]) {
-        options[CBCentralManagerOptionRestoreIdentifierKey] = @"cordova-plugin-ble-central";
+    if (enableState != nil && [enableState length] > 0) {
+        NSString *restoreIdentifier = [@"true" isEqualToString:[enableState lowercaseString]]
+            ? [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleIdentifier"]
+            : enableState;
+        options[CBCentralManagerOptionRestoreIdentifierKey] = restoreIdentifier;
     }
 
     peripherals = [NSMutableSet new];

--- a/src/ios/BLECentralPlugin.m
+++ b/src/ios/BLECentralPlugin.m
@@ -37,8 +37,17 @@
 
     [super pluginInitialize];
 
+    NSMutableDictionary *options = [[NSMutableDictionary alloc] init];
+    options[CBCentralManagerOptionShowPowerAlertKey] = @NO;
+
+    NSDictionary *pluginSettings = [[self commandDelegate] settings];
+    NSString *enableState = pluginSettings[@"bluetooth_restore_state"];
+    if (enableState != nil && [@"true" isEqualToString:[enableState lowercaseString]]) {
+        options[CBCentralManagerOptionRestoreIdentifierKey] = @"cordova-plugin-ble-central";
+    }
+
     peripherals = [NSMutableSet new];
-    manager = [[CBCentralManager alloc] initWithDelegate:self queue:nil options:@{CBCentralManagerOptionShowPowerAlertKey: @NO}];
+    manager = [[CBCentralManager alloc] initWithDelegate:self queue:nil options:options];
 
     connectCallbacks = [NSMutableDictionary new];
     connectCallbackLatches = [NSMutableDictionary new];
@@ -59,6 +68,9 @@
 }
 
 #pragma mark - Cordova Plugin Methods
+
+- (void)centralManager:(CBCentralManager *)central willRestoreState:(NSDictionary<NSString *,id> *)state {
+}
 
 // TODO add timeout
 - (void)connect:(CDVInvokedUrlCommand *)command {

--- a/src/ios/CBPeripheral+Extensions.m
+++ b/src/ios/CBPeripheral+Extensions.m
@@ -50,6 +50,23 @@ static NSDictionary *dataToArrayBuffer(NSData* data) {
     NSMutableDictionary *dictionary = [NSMutableDictionary dictionary];
     [dictionary setObject: uuidString forKey: @"id"];
 
+    NSString *state;
+    switch ([self state]) {
+        case CBPeripheralStateDisconnected:
+            state = @"disconnected";
+            break;
+        case CBPeripheralStateConnecting:
+            state = @"connecting";
+            break;
+        case CBPeripheralStateConnected:
+            state = @"connected";
+            break;
+        case CBPeripheralStateDisconnecting:
+            state = @"disconnecting";
+            break;
+    }
+    [dictionary setObject: state forKey:@"state"];
+
     if ([self name]) {
         [dictionary setObject: [self name] forKey: @"name"];
     }

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,4 +1,6 @@
 declare namespace BLECentralPlugin {
+    type PeripheralState = 'disconnected' | 'disconnecting' | 'connecting' | 'connected';
+
     interface PeripheralCharacteristic {
         service: string;
         characteristic: string;
@@ -11,6 +13,7 @@ declare namespace BLECentralPlugin {
         id: string;
         rssi: number;
         advertising: ArrayBuffer | any;
+        state: PeripheralState;
     }
 
     interface PeripheralDataExtended extends PeripheralData {
@@ -26,6 +29,12 @@ declare namespace BLECentralPlugin {
 
     interface StartScanOptions {
         reportDuplicates?: boolean | undefined;
+    }
+
+    interface RestoredState {
+        peripherals?: PeripheralDataExtended[];
+        scanServiceUUIDs?: string[];
+        scanOptions?: Record<string, any>;
     }
 
     interface BLECentralPluginCommon {
@@ -90,6 +99,7 @@ declare namespace BLECentralPlugin {
         showBluetoothSettings(): Promise<void>;
         stopStateNotifications(): Promise<void>;
         readRSSI(device_id: string): Promise<number>;
+        restoredBluetoothState(): Promise<RestoredState | undefined>;
     }
 
     export interface BLECentralPluginStatic extends BLECentralPluginCommon {
@@ -166,7 +176,7 @@ declare namespace BLECentralPlugin {
            [iOS] requestConnectionPriority is not supported on iOS. */
         requestConnectionPriority(
             device_id: string,
-            priority: "high" | "balanced" | "low",
+            priority: 'high' | 'balanced' | 'low',
             success?: () => any,
             failure?: () => any
         ): void;
@@ -214,6 +224,12 @@ declare namespace BLECentralPlugin {
         /* Find the bonded devices.
                    [iOS] bondedDevices is not supported on iOS. */
         bondedDevices(success: (data: PeripheralData[]) => any, failure: () => any): void;
+
+        /* Reports the BLE restoration status if the app was restarted by iOS
+           as a result of a BLE event.
+           See https://developer.apple.com/library/archive/documentation/NetworkingInternetWeb/Conceptual/CoreBluetooth_concepts/CoreBluetoothBackgroundProcessingForIOSApps/PerformingTasksWhileYourAppIsInTheBackground.html#//apple_ref/doc/uid/TP40013257-CH7-SW10
+            [Android] restoredBluetoothState is not supported on Android. */
+        restoredBluetoothState(success: (data: RestoredState) => any, failure: () => any): void;
 
         withPromises: BLECentralPluginPromises;
     }

--- a/www/ble.js
+++ b/www/ble.js
@@ -250,6 +250,10 @@ module.exports = {
     stopStateNotifications: function (success, failure) {
         cordova.exec(success, failure, 'BLE', 'stopStateNotifications', []);
     },
+
+    restoredBluetoothState: function (success, failure) {
+        cordova.exec(success, failure, 'BLE', 'restoredBluetoothState', []);
+    },
 };
 
 module.exports.withPromises = {
@@ -341,6 +345,12 @@ module.exports.withPromises = {
     readRSSI: function (device_id) {
         return new Promise(function (resolve, reject) {
             module.exports.readRSSI(device_id, resolve, reject);
+        });
+    },
+
+    restoredBluetoothState: function () {
+        return new Promise(function (resolve, reject) {
+            module.exports.restoredBluetoothState(resolve, reject);
         });
     },
 };


### PR DESCRIPTION
Feature can be activated by setting BLUETOOTH_RESTORE_STATE to true.

iOS connect now also checks for previously discovered peripheral. When used in conjunction with iOS state restoration, allows a previously-known peripheral to be reconnected to directly without needing another peripheral scan.

This brings the behaviour into alignment with Android.