### PR TITLE
Add withPromises.startNotification that resolves only when notification has been registered on peripheral

### DIFF
--- a/src/android/Peripheral.java
+++ b/src/android/Peripheral.java
@@ -532,6 +532,7 @@ public class Peripheral extends BluetoothGattCallback {
 
         if (!gatt.setCharacteristicNotification(characteristic, true)) {
             callbackContext.error("Failed to register notification for " + characteristicUUID);
+            notificationCallbacks.remove(key);
             commandCompleted();
             return;
         }
@@ -540,6 +541,7 @@ public class Peripheral extends BluetoothGattCallback {
         BluetoothGattDescriptor descriptor = characteristic.getDescriptor(CLIENT_CHARACTERISTIC_CONFIGURATION_UUID);
         if (descriptor == null) {
             callbackContext.error("Set notification failed for " + characteristicUUID);
+            notificationCallbacks.remove(key);
             commandCompleted();
             return;
         }
@@ -555,6 +557,7 @@ public class Peripheral extends BluetoothGattCallback {
 
         if (!gatt.writeDescriptor(descriptor)) {
             callbackContext.error("Failed to set client characteristic notification for " + characteristicUUID);
+            notificationCallbacks.remove(key);
             commandCompleted();
         }
 

--- a/src/ios/BLECentralPlugin.m
+++ b/src/ios/BLECentralPlugin.m
@@ -776,7 +776,9 @@
             // successfully started notifications
             // notification start succeeded, move the callback to the value notifications dict
             [notificationCallbacks setObject:startNotificationCallbackId forKey:key];
-            [startNotificationCallbacks removeObjectForKey:key];
+            
+            pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"registered"];
+            [pluginResult setKeepCallbackAsBool:TRUE]; // keep for notification
         } else {
             if (error) {
                 // error: something went wrong
@@ -787,10 +789,10 @@
                 NSLog(@"Notifications failed to start");
                 pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Notifications failed to start"];
             }
-
-            [self.commandDelegate sendPluginResult:pluginResult callbackId:startNotificationCallbackId];
-            [startNotificationCallbacks removeObjectForKey:key];
         }
+
+        [self.commandDelegate sendPluginResult:pluginResult callbackId:startNotificationCallbackId];
+        [startNotificationCallbacks removeObjectForKey:key];
     }
 
     if (!characteristic.isNotifying) {

--- a/types.d.ts
+++ b/types.d.ts
@@ -160,13 +160,18 @@ declare namespace BLECentralPlugin {
             failure?: (error: string) => any
         ): void;
 
+        /* Start notifications on the given characteristic
+           - options
+               emitOnRegistered     Default is false. Emit "registered" to success callback 
+                                    when peripheral confirms notifications are active
+          */
         startNotification(
             device_id: string,
             service_uuid: string,
             characteristic_uuid: string,
             success: (rawData: ArrayBuffer | 'registered') => any,
-            failure?: (error: string | BLEError) => any,
-            options: { emitOnRegistered: boolean } = { emitOnRegistered: true }
+            failure: (error: string | BLEError) => any,
+            options: { emitOnRegistered: boolean }
         ): void;
 
         startNotification(

--- a/types.d.ts
+++ b/types.d.ts
@@ -63,15 +63,6 @@ declare namespace BLECentralPlugin {
             connectCallback: (data: PeripheralDataExtended) => any,
             disconnectCallback: (error: string | BLEError) => any
         ): void;
-
-        /* Register to be notified when the value of a characteristic changes. */
-        startNotification(
-            device_id: string,
-            service_uuid: string,
-            characteristic_uuid: string,
-            success: (rawData: ArrayBuffer) => any,
-            failure?: (error: string | BLEError) => any
-        ): void;
     }
 
     export interface BLECentralPluginPromises extends BLECentralPluginCommon {
@@ -84,6 +75,15 @@ declare namespace BLECentralPlugin {
             service_uuid: string,
             characteristic_uuid: string,
             value: ArrayBuffer
+        ): Promise<void>;
+
+        /* Register to be notified when the value of a characteristic changes. */
+        startNotification(
+            device_id: string,
+            service_uuid: string,
+            characteristic_uuid: string,
+            success: (rawData: ArrayBuffer) => any,
+            failure?: (error: string | BLEError) => any
         ): Promise<void>;
         stopNotification(device_id: string, service_uuid: string, characteristic_uuid: string): Promise<void>;
 
@@ -118,8 +118,7 @@ declare namespace BLECentralPlugin {
            [iOS] setPin is not supported on iOS. */
         setPin(pin: string, success?: () => any, failure?: (error: string | BLEError) => any): void;
 
-        stopScan(): void;
-        stopScan(success: () => any, failure?: () => any): void;
+        stopScan(success?: () => any, failure?: () => any): void;
 
         /* Automatically connect to a device when it is in range of the phone
            [iOS] background notifications on ios must be enabled if you want to run in the background
@@ -159,6 +158,23 @@ declare namespace BLECentralPlugin {
             data: ArrayBuffer,
             success?: () => any,
             failure?: (error: string) => any
+        ): void;
+
+        startNotification(
+            device_id: string,
+            service_uuid: string,
+            characteristic_uuid: string,
+            success: (rawData: ArrayBuffer | 'registered') => any,
+            failure?: (error: string | BLEError) => any,
+            options: { emitOnRegistered: boolean } = { emitOnRegistered: true }
+        ): void;
+
+        startNotification(
+            device_id: string,
+            service_uuid: string,
+            characteristic_uuid: string,
+            success: (rawData: ArrayBuffer) => any,
+            failure?: (error: string | BLEError) => any
         ): void;
 
         stopNotification(

--- a/types.d.ts
+++ b/types.d.ts
@@ -72,8 +72,6 @@ declare namespace BLECentralPlugin {
             success: (rawData: ArrayBuffer) => any,
             failure?: (error: string | BLEError) => any
         ): void;
-
-        startStateNotifications(success: (state: string) => any, failure?: (error: string) => any): void;
     }
 
     export interface BLECentralPluginPromises extends BLECentralPluginCommon {
@@ -97,8 +95,20 @@ declare namespace BLECentralPlugin {
 
         enable(): Promise<void>;
         showBluetoothSettings(): Promise<void>;
+
+        /** Registers a change listener for Bluetooth adapter state changes */
+        startStateNotifications(success: (state: string) => any, failure?: (error: string) => any): Promise<void>;
+
         stopStateNotifications(): Promise<void>;
+
+        /* Registers a change listener for location-related services.
+           [iOS] startLocationStateNotifications is not supported on iOS. */
+        startLocationStateNotifications(
+            change: (isLocationEnabled: boolean) => any,
+            failure?: (error: string) => any
+        ): Promise<void>;
         stopLocationStateNotifications(): Promise<void>;
+
         readRSSI(device_id: string): Promise<number>;
         restoredBluetoothState(): Promise<RestoredState | undefined>;
     }
@@ -191,6 +201,9 @@ declare namespace BLECentralPlugin {
             success?: (data: PeripheralDataExtended) => any,
             failure?: (error: string | BLEError) => any
         ): void;
+
+        /** Registers a change listener for Bluetooth adapter state changes */
+        startStateNotifications(success: (state: string) => any, failure?: (error: string) => any): void;
 
         stopStateNotifications(success?: () => any, failure?: () => any): void;
 

--- a/www/ble.js
+++ b/www/ble.js
@@ -244,11 +244,11 @@ module.exports = {
     },
 
     startLocationStateNotifications: function (success, failure) {
-      cordova.exec(success, failure, "BLE", "startLocationStateNotifications", []);
+        cordova.exec(success, failure, 'BLE', 'startLocationStateNotifications', []);
     },
 
     stopLocationStateNotifications: function (success, failure) {
-      cordova.exec(success, failure, "BLE", "stopLocationStateNotifications", []);
+        cordova.exec(success, failure, 'BLE', 'stopLocationStateNotifications', []);
     },
 
     startStateNotifications: function (success, failure) {
@@ -270,7 +270,6 @@ module.exports.withPromises = {
     startScanWithOptions: module.exports.startScanWithOptions,
     connect: module.exports.connect,
     startNotification: module.exports.startNotification,
-    startStateNotifications: module.exports.startStateNotifications,
 
     stopScan: function () {
         return new Promise(function (resolve, reject) {
@@ -344,16 +343,46 @@ module.exports.withPromises = {
         });
     },
 
+    startStateNotifications: function (success, failure) {
+        return new Promise(function (resolve, reject) {
+            module.exports.startStateNotifications(
+                function (state) {
+                    resolve();
+                    success(state);
+                },
+                function (err) {
+                    reject(err);
+                    failure(err);
+                }
+            );
+        });
+    },
+
     stopStateNotifications: function () {
         return new Promise(function (resolve, reject) {
             module.exports.stopStateNotifications(resolve, reject);
         });
     },
 
+    startLocationStateNotifications: function (change, failure) {
+        return new Promise(function (resolve, reject) {
+            module.exports.startLocationStateNotifications(
+                function (state) {
+                    resolve();
+                    change(state);
+                },
+                function (err) {
+                    reject(err);
+                    failure(err);
+                }
+            );
+        });
+    },
+
     stopLocationStateNotifications: function () {
-      return new Promise(function(resolve, reject) {
-          module.exports.stopLocationStateNotifications(resolve, reject);
-      });
+        return new Promise(function (resolve, reject) {
+            module.exports.stopLocationStateNotifications(resolve, reject);
+        });
     },
 
     readRSSI: function (device_id) {


### PR DESCRIPTION
Addressing #95 , this approach is backwards compatible with existing code, but enables implementations to be confident notification registration has succeeded with the peripheral before continuing with additional commands.