### PR TITLE
Make connect failure errors on iOS more concise

### DIFF
--- a/src/ios/BLECentralPlugin.m
+++ b/src/ios/BLECentralPlugin.m
@@ -736,8 +736,20 @@
     [connectCallbacks removeObjectForKey:[peripheral uuidAsString]];
     [self cleanupOperationCallbacks:peripheral withResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Peripheral disconnected"]];
 
+    NSMutableDictionary *dict = [NSMutableDictionary dictionaryWithDictionary:[peripheral asDictionary]];
+
+    // add error info
+    [dict setObject:@"Connection Failed" forKey:@"errorMessage"];
+    if (error) {
+        [dict setObject:[error localizedDescription] forKey:@"errorDescription"];
+    }
+    // remove extra junk
+    [dict removeObjectForKey:@"rssi"];
+    [dict removeObjectForKey:@"advertising"];
+    [dict removeObjectForKey:@"services"];
+
     CDVPluginResult *pluginResult = nil;
-    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsDictionary:[peripheral asDictionary]];
+    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsDictionary:dict];
     [self.commandDelegate sendPluginResult:pluginResult callbackId:connectCallbackId];
 }
 


### PR DESCRIPTION
When setup of a connection to a peripheral fails on iOS, the error object is rather bulky and doesn't include info on what happened. For example, an error might look like:
```
{
  id: "632FAD99-9220-6939-5C9D-0D4F0C46DE2C",
  rssi: -50,
  advertising: {
    kCBAdvDataLocalName: "LCM3-00015",
    kCBAdvDataIsConnectable: 1,
    kCBAdvDataServiceUUIDs: [Object],
  },
  name: "LCM3-00015",
}
```

`didDisconnectPeripheral` presently strips out `rssi`, `advertising`, and `services`, and adds `errorDescription` to indicate what went wrong. This PR makes `didFailToConnectPeripheral` do the same.