### PR TITLE
Restore refreshDeviceCache behaviours

### DIFF
--- a/src/android/BLECentralPlugin.java
+++ b/src/android/BLECentralPlugin.java
@@ -1067,6 +1067,19 @@ public class BLECentralPlugin extends CordovaPlugin {
             if (!PermissionHelper.hasPermission(this, BLUETOOTH_CONNECT)) {
                 missingPermissions.add(BLUETOOTH_CONNECT);
             }
+        } else if (COMPILE_SDK_VERSION >= 30 && Build.VERSION.SDK_INT >= 30) { // (API 30) Build.VERSION_CODES.R
+            // Android 11 specifically requires FINE location access to be granted first before
+            // the app is allowed to ask for ACCESS_BACKGROUND_LOCATION
+            // Source: https://developer.android.com/about/versions/11/privacy/location
+            if (!PermissionHelper.hasPermission(this, Manifest.permission.ACCESS_FINE_LOCATION)) {
+                missingPermissions.add(Manifest.permission.ACCESS_FINE_LOCATION);
+            } else {
+                String accessBackgroundLocation = this.preferences.getString("accessBackgroundLocation", "false");
+                if (accessBackgroundLocation == "true" &&  !PermissionHelper.hasPermission(this, ACCESS_BACKGROUND_LOCATION)) {
+                    LOG.w(TAG, "ACCESS_BACKGROUND_LOCATION is being requested");
+                    missingPermissions.add(ACCESS_BACKGROUND_LOCATION);
+                }
+            }
         } else if (COMPILE_SDK_VERSION >= 29 && Build.VERSION.SDK_INT >= 29) { // (API 29) Build.VERSION_CODES.Q
             if (!PermissionHelper.hasPermission(this, Manifest.permission.ACCESS_FINE_LOCATION)) {
                 missingPermissions.add(Manifest.permission.ACCESS_FINE_LOCATION);

--- a/src/android/L2CAPContext.java
+++ b/src/android/L2CAPContext.java
@@ -110,9 +110,10 @@ class L2CAPContext {
     @RequiresApi(api = Build.VERSION_CODES.M)
     private void readL2CapData() {
         try {
-            InputStream inputStream = socket.getInputStream();
-            byte[] buffer = new byte[socket.getMaxReceivePacketSize()];
-            while (socket.isConnected()) {
+            final BluetoothSocket lSocket = this.socket;
+            InputStream inputStream = lSocket.getInputStream();
+            byte[] buffer = new byte[lSocket.getMaxReceivePacketSize()];
+            while (lSocket.isConnected()) {
                 int readCount = inputStream.read(buffer);
                 CallbackContext receiver;
                 synchronized (updateLock) {

--- a/src/android/Peripheral.java
+++ b/src/android/Peripheral.java
@@ -229,11 +229,17 @@ public class Peripheral extends BluetoothGattCallback {
                     if (success) {
                         this.refreshCallback = callback;
                         Handler handler = new Handler();
+                        LOG.d(TAG, "Waiting " + timeoutMillis + " milliseconds before discovering services");
                         handler.postDelayed(new Runnable() {
                             @Override
                             public void run() {
-                                LOG.d(TAG, "Waiting " + timeoutMillis + " milliseconds before discovering services");
-                                gatt.discoverServices();
+                                if (gatt != null) {
+                                    try {
+                                        gatt.discoverServices();
+                                    } catch(Exception e) {
+                                        LOG.e(TAG, "refreshDeviceCache Failed after delay", e);
+                                    }
+                                }
                             }
                         }, timeoutMillis);
                     }

--- a/src/android/Peripheral.java
+++ b/src/android/Peripheral.java
@@ -105,6 +105,10 @@ public class Peripheral extends BluetoothGattCallback {
         currentActivity = activity;
         autoconnect = auto;
         connectCallback = callbackContext;
+        if (refreshCallback != null) {
+            refreshCallback.error(this.asJSONObject("refreshDeviceCache aborted due to new connect call"));
+            refreshCallback = null;
+        }
 
         gattConnect();
 

--- a/src/android/Peripheral.java
+++ b/src/android/Peripheral.java
@@ -384,9 +384,7 @@ public class Peripheral extends BluetoothGattCallback {
             if (refreshCallback != null) {
                 refreshCallback.sendPluginResult(result);
                 refreshCallback = null;
-            }
-            
-            if (connectCallback != null) {
+            } else if (connectCallback != null) {
                 connectCallback.sendPluginResult(result);
             }
         } else {

--- a/types.d.ts
+++ b/types.d.ts
@@ -5,7 +5,7 @@ declare namespace BLECentralPlugin {
         service: string;
         characteristic: string;
         properties: string[];
-        descriptors?: any[] | undefined;
+        descriptors?: any[];
     }
 
     interface PeripheralData {
@@ -28,7 +28,22 @@ declare namespace BLECentralPlugin {
     }
 
     interface StartScanOptions {
-        reportDuplicates?: boolean | undefined;
+        /* Android only */
+        scanMode?: 'lowPower' | 'balanced' | 'lowLatency' | 'opportunistic';
+        /* Android only */
+        callbackType?: 'all' | 'first' | 'lost';
+        /* Android only */
+        matchMode?: 'aggressive' | 'sticky';
+        /* Android only */
+        numOfMatches?: 'one' | 'few' | 'max';
+        /* Android only */
+        phy?: '1m' | 'coded' | 'all';
+        /* Android only */
+        legacy?: boolean;
+        /* Android only */
+        reportDelay?: number;
+
+        reportDuplicates?: boolean;
     }
 
     interface L2CAPOptions {
@@ -223,7 +238,7 @@ declare namespace BLECentralPlugin {
             service_uuid: string,
             characteristic_uuid: string,
             success: (rawData: ArrayBuffer | 'registered') => any,
-            failure?: (error: string | BLEError) => any,
+            failure: (error: string | BLEError) => any,
             options: { emitOnRegistered: boolean }
         ): void;
 


### PR DESCRIPTION
The refresh device cache behaviour changed in https://github.com/don/cordova-plugin-ble-central/commit/4a481207e0b0a3a31e8a1109f5498fa675cebfeb to call both the refresh device cache callback AND the connect callback when service discovery finished.

This may result in some confusing behaviour if an application is relying on the connect callback to trigger the refresh of the cache, that may result in an (effectively) infinite loop.

This fix here is to restore the original behaviour (service discovery triggers either the refresh callback or the connect callback). An additional tweak was made so that a new connect callback will clear any existing pending refresh callbacks, to avoid any issues where a connect may never complete due to an unfinished refresh.

Issue related to #936