### PR TITLE
fix: android 12 enable permissions call

### DIFF
--- a/src/android/BLECentralPlugin.java
+++ b/src/android/BLECentralPlugin.java
@@ -344,8 +344,19 @@ public class BLECentralPlugin extends CordovaPlugin {
         } else if (action.equals(ENABLE)) {
 
             enableBluetoothCallback = callbackContext;
-            Intent intent = new Intent(BluetoothAdapter.ACTION_REQUEST_ENABLE);
-            cordova.startActivityForResult(this, intent, REQUEST_ENABLE_BLUETOOTH);
+
+          //check android12+ - perms should be asked in a bulk
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                String[] ANDROID_12_BLE_PERMISSIONS = new String[]{
+                Manifest.permission.BLUETOOTH_SCAN,
+                Manifest.permission.BLUETOOTH_CONNECT
+                };
+                cordova.requestPermissions(this, REQUEST_ENABLE_BLUETOOTH, ANDROID_12_BLE_PERMISSIONS);
+            }
+            else{
+                Intent intent = new Intent(BluetoothAdapter.ACTION_REQUEST_ENABLE);
+                cordova.startActivityForResult(this, intent, REQUEST_ENABLE_BLUETOOTH);
+            }
 
         } else if (action.equals(START_STATE_NOTIFICATIONS)) {
 
@@ -1227,6 +1238,12 @@ public class BLECentralPlugin extends CordovaPlugin {
         }
 
         switch(requestCode) {
+            case REQUEST_ENABLE_BLUETOOTH:
+                LOG.d(TAG, "User enabled Bluetooth");
+                if (enableBluetoothCallback != null) {
+                    enableBluetoothCallback.success();
+                }
+                break;
             case REQUEST_BLUETOOTH_SCAN:
                 LOG.d(TAG, "User granted Bluetooth Scan Access");
                 findLowEnergyDevices(permissionCallback, serviceUUIDs, scanSeconds, scanSettings);


### PR DESCRIPTION
Possible fix for an issue https://github.com/don/cordova-plugin-ble-central/issues/940

Calling a window.ble.enable method throws an exception.

The exception:
`java.lang.SecurityException: Permission Denial: starting Intent { act=android.bluetooth.adapter.action.REQUEST_ENABLE cmp=com.android.settings/.bluetooth.RequestPermissionActivity } from ProcessRecord{83ef7f3 12239:org.[my appname]/u0a337} (pid=12239, uid=10337) requires android.permission.BLUETOOTH_CONNECT`

Calling new android 12 scan and connect permissions in a bulk fixes the issue.