### PR TITLE
Add new module ble-central-advertisements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1296,7 +1296,8 @@ Bluetooth advertising data is returned in when scanning for devices. The format 
 
 The advertising information for both Android and iOS appears to be a combination of advertising data and scan response data.
 
-Ideally a common format (map or array) would be returned for both platforms in future versions. If you have ideas, please contact me.
+To get consistent advertising data payloads across platforms, you can use
+the [ble-central-advertisements](https://github.com/jospete/ble-central-advertisements) module.
 
 ## Android
 


### PR DESCRIPTION
I've created a module to unify disparities between android and ios advertising payloads, and parse raw android advertising data based on the Bluetooth GAP specification so it can match the pre-parsed ios data.

@don if this module looks good to you, I'd like to refer people to it in the main README so they can skip a lot of the boilerplate that comes along with raw android advertisements. 