### PR TITLE
fix: added mtu to success callback

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -297,7 +297,7 @@ declare namespace BLECentralPlugin {
 
         /* May be used to request (on Android) a larger MTU size to be able to send more data at once
            [iOS] requestMtu is not supported on iOS. */
-        requestMtu(device_id: string, mtu: number, success?: () => any, failure?: () => any): void;
+        requestMtu(device_id: string, mtu: number, success?: (mtu: number) => any, failure?: () => any): void;
 
         /* When Connecting to a peripheral android can request for the connection priority for faster communication.
            [iOS] requestConnectionPriority is not supported on iOS. */


### PR DESCRIPTION
In the requestMtu success callback the applied mtu is passed as a parameter. However this parameter is missing in the types.d.ts